### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
 		"@versini/dev-dependencies-client": "6.0.1",
 		"@versini/dev-dependencies-types": "1.3.4"
 	},
-	"packageManager": "pnpm@9.8.0+sha512.8e4c3550fb500e808dbc30bb0ce4dd1eb614e30b1c55245f211591ec2cdf9c611cabd34e1364b42f564bd54b3945ed0f49d61d1bbf2ec9bd74b866fcdc723276"
+	"packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,7 +26,7 @@
 		"@versini/ui-styles": "1.9.5"
 	},
 	"dependencies": {
-		"@versini/auth-provider": "7.1.1",
+		"@versini/auth-provider": "7.1.2",
 		"@versini/ui-components": "5.21.2",
 		"@versini/ui-form": "1.3.7",
 		"@versini/ui-hooks": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   packages/client:
     dependencies:
       '@versini/auth-provider':
-        specifier: 7.1.1
-        version: 7.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.1.2
+        version: 7.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-components':
         specifier: 5.21.2
         version: 5.21.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1398,8 +1398,8 @@ packages:
   '@versini/auth-common@4.0.0':
     resolution: {integrity: sha512-adVfzk703mzZ6nFlqPh2R8r4wDxkZMbPpDuUrnl+8GpEmdB1+cwNxnE4Ec/PgqEEhHZnB6I+YSs4I+HHp3zd7g==}
 
-  '@versini/auth-provider@7.1.1':
-    resolution: {integrity: sha512-Ihb1yUkkYZ+YhoA4McaM4atAb98e9KiaA6TA+X2ms82dhdVgQQVbkq7lfLOmF/3cG5TKySYAAQfJTdkS2Ex7lA==}
+  '@versini/auth-provider@7.1.2':
+    resolution: {integrity: sha512-95hMNprvjQrRgLRNdC1z6woo3YH1UDTaKMZA5fkjAf9z2E1GPZ64FEx8Vo7Zckz0Tm8ZeFaWE6zVsb0VA/Eb0w==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -5860,7 +5860,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
     optional: true
 
   '@lerna/create@8.1.8(@swc/core@1.5.24(@swc/helpers@0.5.11))(encoding@0.1.13)(typescript@5.5.4)':
@@ -6813,7 +6813,7 @@ snapshots:
       jose: 5.7.0
       uuid: 10.0.0
 
-  '@versini/auth-provider@7.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/auth-provider@7.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@simplewebauthn/browser': 10.0.0
       '@versini/auth-common': 4.0.0


### PR DESCRIPTION
### **PR Type**
enhancement, dependencies


___

### **Description**
- Updated the `packageManager` in `package.json` to use `pnpm@9.9.0`.
- Bumped the `@versini/auth-provider` dependency version from `7.1.1` to `7.1.2` in `packages/client/package.json`.
- Updated `pnpm-lock.yaml` to reflect changes in dependency versions, including `@versini/auth-provider` and `@jridgewell/sourcemap-codec`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update package manager version in package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Updated the <code>packageManager</code> version from <code>pnpm@9.8.0</code> to <code>pnpm@9.9.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/versini-org/sassysaint-ui/pull/570/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump auth-provider dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/client/package.json

<li>Updated <code>@versini/auth-provider</code> dependency from version <code>7.1.1</code> to <code>7.1.2</code>.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/versini-org/sassysaint-ui/pull/570/files#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Update lock file with new dependency versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

<li>Updated <code>@versini/auth-provider</code> version from <code>7.1.1</code> to <code>7.1.2</code>.<br> <li> Updated <code>@jridgewell/sourcemap-codec</code> version from <code>1.4.15</code> to <code>1.5.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/versini-org/sassysaint-ui/pull/570/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

