### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "4.3.5",
-	"packages/component": "4.3.5"
+	"packages/client": "4.3.6",
+	"packages/component": "5.0.0"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.3.6](https://github.com/versini-org/sassysaint-ui/compare/client-v4.3.5...client-v4.3.6) (2024-09-14)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([5ca775f](https://github.com/versini-org/sassysaint-ui/commit/5ca775fadae71188689d78b6a0b89ff6ee912167))
+
 ## [4.3.5](https://github.com/versini-org/sassysaint-ui/compare/client-v4.3.4...client-v4.3.5) (2024-09-10)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "4.3.5",
+	"version": "4.3.6",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -4074,5 +4074,73 @@
       "limit": "8 kb",
       "passed": true
     }
+  },
+  "4.3.6": {
+    "dist/static/js/index.<hash>.js": {
+      "fileSize": 17563,
+      "fileSizeGzip": 5936,
+      "limit": "7 kb",
+      "passed": true
+    },
+    "dist/static/js/*versini_auth-provider*.<hash>.js": {
+      "fileSize": 83801,
+      "fileSizeGzip": 23018,
+      "limit": "28 kb",
+      "passed": true
+    },
+    "dist/static/js/lib-react.<hash>.js": {
+      "fileSize": 141669,
+      "fileSizeGzip": 45220,
+      "limit": "45 kb",
+      "passed": true
+    },
+    "dist/static/js/async/*Messages_LazyHeader*.<hash>.js": {
+      "fileSize": 22551,
+      "fileSizeGzip": 5984,
+      "limit": "6 kb",
+      "passed": true
+    },
+    "dist/static/js/async/node_modules*versini_ui-components*.<hash>.js": {
+      "fileSize": 5384,
+      "fileSizeGzip": 2094,
+      "limit": "5 kb",
+      "passed": true
+    },
+    "dist/static/js/async/*App_App*.<hash>.js": {
+      "fileSize": 16446,
+      "fileSizeGzip": 5332,
+      "limit": "8 kb",
+      "passed": true
+    },
+    "dist/static/js/async/*react-use*.<hash>.js": {
+      "fileSize": 85519,
+      "fileSizeGzip": 26437,
+      "limit": "32 kb",
+      "passed": true
+    },
+    "dist/static/js/async/*katex*.<hash>.js": {
+      "fileSize": 160007,
+      "fileSizeGzip": 45185,
+      "limit": "51 kb",
+      "passed": true
+    },
+    "dist/static/js/async/*rehype-highlight*.<hash>.js": {
+      "fileSize": 442007,
+      "fileSizeGzip": 127325,
+      "limit": "130 kb",
+      "passed": true
+    },
+    "dist/static/css/index.<hash>.css": {
+      "fileSize": 70976,
+      "fileSizeGzip": 10396,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "dist/static/css/async/vendors-*katex*.<hash>.css": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "8 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [5.0.0](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v4.3.5...sassysaint-v5.0.0) (2024-09-14)
+
+
+### ⚠ BREAKING CHANGES
+
+* using new AuthProvider v7 that uses the new Auth Server v9
+
+### Features
+
+* adding email to profile content ([fa3a140](https://github.com/versini-org/sassysaint-ui/commit/fa3a140356efc5957e858141316866e0ddfa3833))
+* export as a component ([f81e0bd](https://github.com/versini-org/sassysaint-ui/commit/f81e0bd01cb83ee8dd960c853c7421c98b51c393))
+* export as a component ([dcf0117](https://github.com/versini-org/sassysaint-ui/commit/dcf0117ca63b4c1b3d6b246e43df45f87f7bd336))
+* using new AuthProvider v7 that uses the new Auth Server v9 ([3954285](https://github.com/versini-org/sassysaint-ui/commit/39542850f924180443fdf4d1c4638bd021fa982e))
+
+
+### Bug Fixes
+
+* adding debug support for auth ([301e051](https://github.com/versini-org/sassysaint-ui/commit/301e051fa6303954e0bb999d6b118332a88d31f4))
+* bump dependencies to latest ([292d5d4](https://github.com/versini-org/sassysaint-ui/commit/292d5d4f4e7b6ff80111c624920a912cbd4230e4))
+* bump dependencies to latest ([63f63f3](https://github.com/versini-org/sassysaint-ui/commit/63f63f35ffe6ce46bc2e8c00d43f368d5500a23a))
+* bump dependencies to latest ([a280cfe](https://github.com/versini-org/sassysaint-ui/commit/a280cfe841d39a684c406e6789901e595fabdaaf))
+* bump dependencies to latest ([daa03ff](https://github.com/versini-org/sassysaint-ui/commit/daa03ff5deb48f4ff79b0acf5ad419b29cad23b0))
+* bump non-breaking dependencies to latest ([45addbd](https://github.com/versini-org/sassysaint-ui/commit/45addbd90ce93fb536767016bc2f55e0fd0727c8))
+* bump sassy component ([4f6020c](https://github.com/versini-org/sassysaint-ui/commit/4f6020cecb8f776602b5e854983b9a41ea3c6ede))
+* bump SassySaint component to latest ([2d3b21a](https://github.com/versini-org/sassysaint-ui/commit/2d3b21a643081a593de152e4d07595f16cbf1d2a))
+* bump to latest dependencies ([b4c9d04](https://github.com/versini-org/sassysaint-ui/commit/b4c9d044c85f69f472e60f62978a514322d2ce8a))
+* manual trigger for new component release ([1ac3729](https://github.com/versini-org/sassysaint-ui/commit/1ac3729bdff4bf93685537086991de646e1722d2))
+* manual trigger for new component release ([ca5e820](https://github.com/versini-org/sassysaint-ui/commit/ca5e82043d95400e57c51418000a5a1355fc71df))
+* manual trigger for new component release ([1beaa9e](https://github.com/versini-org/sassysaint-ui/commit/1beaa9ee3ca43e5a7914d6bbae8136f8bab63b82))
+* manually bump sassy component ([d5eacfc](https://github.com/versini-org/sassysaint-ui/commit/d5eacfc52555ca4721eff6d9c7e93e96b38d3441))
+* triggering a new release for the component ([af500ec](https://github.com/versini-org/sassysaint-ui/commit/af500ec02819101aaf948905f39cc89ac4ec2f05))
+* update component version ([23a854f](https://github.com/versini-org/sassysaint-ui/commit/23a854ff54b174951f01801e739ac0a25a9b7aca))
+* wrong version for component - oops ([bcdce2f](https://github.com/versini-org/sassysaint-ui/commit/bcdce2f3cd37067ca11003b51165e88ef6c98eb6))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 4.3.6
+
 ## [4.3.5](https://github.com/versini-org/sassysaint-ui/compare/component-v4.3.4...component-v4.3.5) (2024-09-10)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "4.3.5",
+	"version": "5.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 4.3.6</summary>

## [4.3.6](https://github.com/versini-org/sassysaint-ui/compare/client-v4.3.5...client-v4.3.6) (2024-09-14)


### Bug Fixes

* bump dependencies to latest ([5ca775f](https://github.com/versini-org/sassysaint-ui/commit/5ca775fadae71188689d78b6a0b89ff6ee912167))
</details>

<details><summary>sassysaint: 5.0.0</summary>

## [5.0.0](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v4.3.5...sassysaint-v5.0.0) (2024-09-14)


### ⚠ BREAKING CHANGES

* using new AuthProvider v7 that uses the new Auth Server v9

### Features

* adding email to profile content ([fa3a140](https://github.com/versini-org/sassysaint-ui/commit/fa3a140356efc5957e858141316866e0ddfa3833))
* export as a component ([f81e0bd](https://github.com/versini-org/sassysaint-ui/commit/f81e0bd01cb83ee8dd960c853c7421c98b51c393))
* export as a component ([dcf0117](https://github.com/versini-org/sassysaint-ui/commit/dcf0117ca63b4c1b3d6b246e43df45f87f7bd336))
* using new AuthProvider v7 that uses the new Auth Server v9 ([3954285](https://github.com/versini-org/sassysaint-ui/commit/39542850f924180443fdf4d1c4638bd021fa982e))


### Bug Fixes

* adding debug support for auth ([301e051](https://github.com/versini-org/sassysaint-ui/commit/301e051fa6303954e0bb999d6b118332a88d31f4))
* bump dependencies to latest ([292d5d4](https://github.com/versini-org/sassysaint-ui/commit/292d5d4f4e7b6ff80111c624920a912cbd4230e4))
* bump dependencies to latest ([63f63f3](https://github.com/versini-org/sassysaint-ui/commit/63f63f35ffe6ce46bc2e8c00d43f368d5500a23a))
* bump dependencies to latest ([a280cfe](https://github.com/versini-org/sassysaint-ui/commit/a280cfe841d39a684c406e6789901e595fabdaaf))
* bump dependencies to latest ([daa03ff](https://github.com/versini-org/sassysaint-ui/commit/daa03ff5deb48f4ff79b0acf5ad419b29cad23b0))
* bump non-breaking dependencies to latest ([45addbd](https://github.com/versini-org/sassysaint-ui/commit/45addbd90ce93fb536767016bc2f55e0fd0727c8))
* bump sassy component ([4f6020c](https://github.com/versini-org/sassysaint-ui/commit/4f6020cecb8f776602b5e854983b9a41ea3c6ede))
* bump SassySaint component to latest ([2d3b21a](https://github.com/versini-org/sassysaint-ui/commit/2d3b21a643081a593de152e4d07595f16cbf1d2a))
* bump to latest dependencies ([b4c9d04](https://github.com/versini-org/sassysaint-ui/commit/b4c9d044c85f69f472e60f62978a514322d2ce8a))
* manual trigger for new component release ([1ac3729](https://github.com/versini-org/sassysaint-ui/commit/1ac3729bdff4bf93685537086991de646e1722d2))
* manual trigger for new component release ([ca5e820](https://github.com/versini-org/sassysaint-ui/commit/ca5e82043d95400e57c51418000a5a1355fc71df))
* manual trigger for new component release ([1beaa9e](https://github.com/versini-org/sassysaint-ui/commit/1beaa9ee3ca43e5a7914d6bbae8136f8bab63b82))
* manually bump sassy component ([d5eacfc](https://github.com/versini-org/sassysaint-ui/commit/d5eacfc52555ca4721eff6d9c7e93e96b38d3441))
* triggering a new release for the component ([af500ec](https://github.com/versini-org/sassysaint-ui/commit/af500ec02819101aaf948905f39cc89ac4ec2f05))
* update component version ([23a854f](https://github.com/versini-org/sassysaint-ui/commit/23a854ff54b174951f01801e739ac0a25a9b7aca))
* wrong version for component - oops ([bcdce2f](https://github.com/versini-org/sassysaint-ui/commit/bcdce2f3cd37067ca11003b51165e88ef6c98eb6))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 4.3.6
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).