### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "4.5.0",
-	"packages/component": "5.1.1"
+	"packages/client": "4.5.1",
+	"packages/component": "5.1.2"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.5.1](https://github.com/versini-org/sassysaint-ui/compare/client-v4.5.0...client-v4.5.1) (2024-09-25)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([943a177](https://github.com/versini-org/sassysaint-ui/commit/943a1771a1e50ccf69667ba05bec58f89d13f421))
+
 ## [4.5.0](https://github.com/versini-org/sassysaint-ui/compare/client-v4.4.0...client-v4.5.0) (2024-09-24)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "4.5.0",
+	"version": "4.5.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.1.2](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.1...sassysaint-v5.1.2) (2024-09-25)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([943a177](https://github.com/versini-org/sassysaint-ui/commit/943a1771a1e50ccf69667ba05bec58f89d13f421))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 4.5.1
+
 ## [5.1.1](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.0...sassysaint-v5.1.1) (2024-09-24)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 4.5.1</summary>

## [4.5.1](https://github.com/versini-org/sassysaint-ui/compare/client-v4.5.0...client-v4.5.1) (2024-09-25)


### Bug Fixes

* bump non-breaking dependencies to latest ([943a177](https://github.com/versini-org/sassysaint-ui/commit/943a1771a1e50ccf69667ba05bec58f89d13f421))
</details>

<details><summary>sassysaint: 5.1.2</summary>

## [5.1.2](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.1...sassysaint-v5.1.2) (2024-09-25)


### Bug Fixes

* bump non-breaking dependencies to latest ([943a177](https://github.com/versini-org/sassysaint-ui/commit/943a1771a1e50ccf69667ba05bec58f89d13f421))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 4.5.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).