### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "4.5.3",
-	"packages/component": "5.1.4"
+	"packages/client": "5.0.0",
+	"packages/component": "5.1.5"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [5.0.0](https://github.com/versini-org/sassysaint-ui/compare/client-v4.5.3...client-v5.0.0) (2024-10-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* this feature requires server v4+
+
+### Features
+
+* adding option to choose between OpenAI and Anthropic ([fda7a83](https://github.com/versini-org/sassysaint-ui/commit/fda7a83f8a5f9e79a0ccc1130b5319600d062171))
+
 ## [4.5.3](https://github.com/versini-org/sassysaint-ui/compare/client-v4.5.2...client-v4.5.3) (2024-09-30)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "4.5.3",
+	"version": "5.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -4436,5 +4436,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.0.0": {
+    "Initial CSS": {
+      "fileSize": 69550,
+      "fileSizeGzip": 10149,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 240174,
+      "fileSizeGzip": 73813,
+      "limit": "73 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 64890,
+      "fileSizeGzip": 13806,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 138521,
+      "fileSizeGzip": 40920,
+      "limit": "41 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161902,
+      "fileSizeGzip": 45945,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442123,
+      "fileSizeGzip": 127659,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.5](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.4...sassysaint-v5.1.5) (2024-10-03)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.0.0
+
 ## [5.1.4](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.3...sassysaint-v5.1.4) (2024-09-30)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.1.4",
+	"version": "5.1.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.0.0</summary>

## [5.0.0](https://github.com/versini-org/sassysaint-ui/compare/client-v4.5.3...client-v5.0.0) (2024-10-03)


### ⚠ BREAKING CHANGES

* this feature requires server v4+

### Features

* adding option to choose between OpenAI and Anthropic ([fda7a83](https://github.com/versini-org/sassysaint-ui/commit/fda7a83f8a5f9e79a0ccc1130b5319600d062171))
</details>

<details><summary>sassysaint: 5.1.5</summary>

## [5.1.5](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.4...sassysaint-v5.1.5) (2024-10-03)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.0.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).