### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.0.2",
-	"packages/component": "5.1.7"
+	"packages/client": "5.1.0",
+	"packages/component": "5.2.0"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.1.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.0.2...client-v5.1.0) (2024-10-05)
+
+
+### Features
+
+* allowing engine toggle directly in the menu ([cf84ff4](https://github.com/versini-org/sassysaint-ui/commit/cf84ff424fcbc302aff563cef54418a07f38f88f))
+
 ## [5.0.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.0.1...client-v5.0.2) (2024-10-03)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.0.2",
+	"version": "5.1.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -4568,5 +4568,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.1.0": {
+    "Initial CSS": {
+      "fileSize": 71714,
+      "fileSizeGzip": 10456,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 240227,
+      "fileSizeGzip": 73831,
+      "limit": "73 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 64609,
+      "fileSizeGzip": 13763,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 152720,
+      "fileSizeGzip": 45471,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161916,
+      "fileSizeGzip": 45955,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442123,
+      "fileSizeGzip": 127659,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.2.0](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.7...sassysaint-v5.2.0) (2024-10-05)
+
+
+### Features
+
+* allowing engine toggle directly in the menu ([cf84ff4](https://github.com/versini-org/sassysaint-ui/commit/cf84ff424fcbc302aff563cef54418a07f38f88f))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.1.0
+
 ## [5.1.7](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.6...sassysaint-v5.1.7) (2024-10-03)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.1.7",
+	"version": "5.2.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.1.0</summary>

## [5.1.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.0.2...client-v5.1.0) (2024-10-05)


### Features

* allowing engine toggle directly in the menu ([cf84ff4](https://github.com/versini-org/sassysaint-ui/commit/cf84ff424fcbc302aff563cef54418a07f38f88f))
</details>

<details><summary>sassysaint: 5.2.0</summary>

## [5.2.0](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.7...sassysaint-v5.2.0) (2024-10-05)


### Features

* allowing engine toggle directly in the menu ([cf84ff4](https://github.com/versini-org/sassysaint-ui/commit/cf84ff424fcbc302aff563cef54418a07f38f88f))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.1.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).