### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.1.0",
-	"packages/component": "5.2.0"
+	"packages/client": "5.2.0",
+	"packages/component": "5.3.0"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.2.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.1.0...client-v5.2.0) (2024-10-05)
+
+
+### Features
+
+* hotkey ctrl+enter is the equivalent on clicking "send" ([4a07213](https://github.com/versini-org/sassysaint-ui/commit/4a0721374407fdd1b003ebc01dc9c7ff0fdda4fb))
+
 ## [5.1.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.0.2...client-v5.1.0) (2024-10-05)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.1.0",
+	"version": "5.2.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -4612,5 +4612,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.2.0": {
+    "Initial CSS": {
+      "fileSize": 71714,
+      "fileSizeGzip": 10456,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 240227,
+      "fileSizeGzip": 73840,
+      "limit": "73 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 65407,
+      "fileSizeGzip": 14126,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 153480,
+      "fileSizeGzip": 45750,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161916,
+      "fileSizeGzip": 45954,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442123,
+      "fileSizeGzip": 127659,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.3.0](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.2.0...sassysaint-v5.3.0) (2024-10-05)
+
+
+### Features
+
+* hotkey ctrl+enter is the equivalent on clicking "send" ([4a07213](https://github.com/versini-org/sassysaint-ui/commit/4a0721374407fdd1b003ebc01dc9c7ff0fdda4fb))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.2.0
+
 ## [5.2.0](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.1.7...sassysaint-v5.2.0) (2024-10-05)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.2.0",
+	"version": "5.3.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.2.0</summary>

## [5.2.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.1.0...client-v5.2.0) (2024-10-05)


### Features

* hotkey ctrl+enter is the equivalent on clicking "send" ([4a07213](https://github.com/versini-org/sassysaint-ui/commit/4a0721374407fdd1b003ebc01dc9c7ff0fdda4fb))
</details>

<details><summary>sassysaint: 5.3.0</summary>

## [5.3.0](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.2.0...sassysaint-v5.3.0) (2024-10-05)


### Features

* hotkey ctrl+enter is the equivalent on clicking "send" ([4a07213](https://github.com/versini-org/sassysaint-ui/commit/4a0721374407fdd1b003ebc01dc9c7ff0fdda4fb))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.2.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).