### PR TITLE
feat: moving the quick engine toggle to the left of the screen

### DIFF
--- a/packages/client/src/modules/Messages/LazyHeader.tsx
+++ b/packages/client/src/modules/Messages/LazyHeader.tsx
@@ -2,10 +2,12 @@ import { useAuth } from "@versini/auth-provider";
 import { ButtonIcon } from "@versini/ui-button";
 import { useLocalStorage } from "@versini/ui-hooks";
 import {
+	IconAnthropic,
 	IconBack,
 	IconChart,
 	IconHistory,
 	IconInfo,
+	IconOpenAI,
 	IconProfile,
 	IconSettings,
 } from "@versini/ui-icons";
@@ -16,6 +18,7 @@ import { useContext, useEffect, useState } from "react";
 import {
 	ACTION_ENGINE,
 	DEFAULT_AI_ENGINE,
+	ENGINE_ANTHROPIC,
 	LOCAL_STORAGE_ENGINE_TOGGLE,
 	LOCAL_STORAGE_PREFIX,
 } from "../../common/constants";
@@ -154,6 +157,61 @@ const LazyHeader = () => {
 			/>
 			<About open={showAbout} onOpenChange={setShowAbout} />
 			<div className="relative">
+				{showEngineToggleInMenu && serverStats && (
+					<div className="absolute bottom-[-28px] left-[-7px]">
+						<Menu
+							mode="dark"
+							focusMode="light"
+							trigger={
+								<ButtonIcon>
+									{state && state.engine === ENGINE_ANTHROPIC ? (
+										<IconAnthropic />
+									) : (
+										<IconOpenAI />
+									)}
+								</ButtonIcon>
+							}
+							defaultPlacement="bottom-start"
+						>
+							<MenuItem raw ignoreClick>
+								<ToggleGroup
+									size="small"
+									mode="dark"
+									focusMode="light"
+									value={engine}
+									onValueChange={async (value: string) => {
+										if (value) {
+											try {
+												await serviceCall({
+													accessToken: await getAccessToken(),
+													type: SERVICE_TYPES.SET_USER_PREFERENCES,
+													params: {
+														user: user?.username,
+														engine: value,
+													},
+												});
+												dispatch({
+													type: ACTION_ENGINE,
+													payload: {
+														engine: value,
+													},
+												});
+											} catch (_error) {
+												// nothing to declare officer
+											}
+										}
+									}}
+								>
+									{serverStats &&
+										serverStats.engines.map((engine) => (
+											<ToggleGroupItem key={engine} value={engine} />
+										))}
+								</ToggleGroup>
+							</MenuItem>
+						</Menu>
+					</div>
+				)}
+
 				<div className="absolute bottom-[-28px] right-[-7px]">
 					<Menu
 						mode="dark"
@@ -186,46 +244,6 @@ const LazyHeader = () => {
 							onClick={onClickAbout}
 							icon={<IconInfo />}
 						/>
-						{showEngineToggleInMenu && serverStats && (
-							<>
-								<MenuSeparator />
-								<MenuItem raw ignoreClick>
-									<ToggleGroup
-										size="small"
-										mode="dark"
-										focusMode="light"
-										value={engine}
-										onValueChange={async (value: string) => {
-											if (value) {
-												try {
-													await serviceCall({
-														accessToken: await getAccessToken(),
-														type: SERVICE_TYPES.SET_USER_PREFERENCES,
-														params: {
-															user: user?.username,
-															engine: value,
-														},
-													});
-													dispatch({
-														type: ACTION_ENGINE,
-														payload: {
-															engine: value,
-														},
-													});
-												} catch (_error) {
-													// nothing to declare officer
-												}
-											}
-										}}
-									>
-										{serverStats &&
-											serverStats.engines.map((engine) => (
-												<ToggleGroupItem key={engine} value={engine} />
-											))}
-									</ToggleGroup>
-								</MenuItem>
-							</>
-						)}
 
 						{state && state.id && !state.isComponent && (
 							<>

--- a/packages/client/src/modules/Profile/FineTuning.tsx
+++ b/packages/client/src/modules/Profile/FineTuning.tsx
@@ -242,14 +242,14 @@ export const FineTuningPanel = ({
 							<Toggle
 								spacing={{ t: 2 }}
 								noBorder
-								label={"Show Engine Toggle in Menu"}
+								label={"Show Quick Engine Toggle"}
 								name={"show-toggle-engine-menu"}
 								onChange={setShowEngineToggleInMenu}
 								checked={showEngineToggleInMenu}
 							/>
 							<p className="text-xs">
-								This option will show the engine toggle in the main menu. This
-								is useful if you want to quickly switch between engines.
+								This option introduces a new menu on the left side of the
+								screen, enabling you to quickly switch between engines.
 							</p>
 						</Card>
 						<Card


### PR DESCRIPTION
This pull request includes several updates to the `LazyHeader` component and the `FineTuningPanel` in the client module. The changes focus on adding new icons, updating constants, and modifying the layout and functionality of the engine toggle in the menu.

### Updates to `LazyHeader` Component:

* Added `IconAnthropic` and `IconOpenAI` to the list of imported icons in `LazyHeader.tsx`. (`packages/client/src/modules/Messages/LazyHeader.tsx`)
* Introduced `ENGINE_ANTHROPIC` constant to the imports in `LazyHeader.tsx`. (`packages/client/src/modules/Messages/LazyHeader.tsx`)
* Updated the layout to conditionally display the engine toggle button with either `IconAnthropic` or `IconOpenAI`, and moved the engine toggle menu to the left side of the screen. (`packages/client/src/modules/Messages/LazyHeader.tsx`) [[1]](diffhunk://#diff-662b46b5db38da1c9593da285c34fe5ec36a3c5b61bfba40a262fb33787c84b1L157-L191) [[2]](diffhunk://#diff-662b46b5db38da1c9593da285c34fe5ec36a3c5b61bfba40a262fb33787c84b1L227-R247)

### Updates to `FineTuningPanel`:

* Changed the label and description of the engine toggle option to reflect the new menu location and functionality. (`packages/client/src/modules/Profile/FineTuning.tsx`)