### PR TITLE
fix: adding some space at the bottom of the "Fine Tuning" panel at smaller viewport

### DIFF
--- a/packages/client/src/modules/Profile/FineTuning.tsx
+++ b/packages/client/src/modules/Profile/FineTuning.tsx
@@ -181,7 +181,11 @@ export const FineTuningPanel = ({
 					onOpenChange={onOpenChange}
 					title={"Engine Fine Tuning"}
 					footer={
-						<Flexgrid columnGap={2} alignHorizontal="flex-end">
+						<Flexgrid
+							columnGap={2}
+							alignHorizontal="flex-end"
+							className="pb-8 sm:pb-0"
+						>
 							<FlexgridItem>
 								<Button
 									mode="dark"


### PR DESCRIPTION
This pull request includes a change to the `FineTuningPanel` component in the `FineTuning.tsx` file to improve the styling of the footer section.

Styling improvements:

* [`packages/client/src/modules/Profile/FineTuning.tsx`](diffhunk://#diff-86bcdc52cf70b65d1cbc7cea7ef4ae56779ffeb2835737b5ce75a7d9f9c3076dL184-R188): Added a `className` attribute to the `Flexgrid` component to apply padding at the bottom, enhancing the layout for different screen sizes.