### PR TITLE
docs: removing obsolete note

### DIFF
--- a/packages/client/src/modules/Profile/FineTuning.tsx
+++ b/packages/client/src/modules/Profile/FineTuning.tsx
@@ -240,8 +240,7 @@ export const FineTuningPanel = ({
 							/>
 							<p className="text-xs">
 								NOTE: Anthropic is currently in beta and may not be as accurate
-								as OpenAI. It also cannot take advantage yet of internal helper
-								tools such as the OpenWeather or Google Images plugin.
+								as OpenAI.
 							</p>
 							<Toggle
 								spacing={{ t: 2 }}


### PR DESCRIPTION
This pull request includes a small change to the `FineTuningPanel` component in the `FineTuning.tsx` file. The change involves updating the note about Anthropic's beta status.

* [`packages/client/src/modules/Profile/FineTuning.tsx`](diffhunk://#diff-86bcdc52cf70b65d1cbc7cea7ef4ae56779ffeb2835737b5ce75a7d9f9c3076dL243-R243): Updated the note to remove the mention of Anthropic's inability to use internal helper tools like OpenWeather or Google Images plugin.