### PR TITLE
fix: search input should not auto complete/capitalize

### DIFF
--- a/packages/client/src/modules/History/HistoryContent.tsx
+++ b/packages/client/src/modules/History/HistoryContent.tsx
@@ -89,6 +89,8 @@ export const HistoryContent = ({
 				<>
 					<form autoComplete="off" onSubmit={onSubmit}>
 						<TextInput
+							autoComplete="off"
+							autoCorrect="off"
 							ref={inputRef}
 							defaultValue={historyState.searchString}
 							focusMode="light"


### PR DESCRIPTION
This pull request includes a small change to the `HistoryContent` component in the `HistoryContent.tsx` file. The change ensures that the text input field has both `autoComplete` and `autoCorrect` attributes set to "off".

* [`packages/client/src/modules/History/HistoryContent.tsx`](diffhunk://#diff-1e332737525e48a576e60868e907180090ef00dede671deafc81fc477449801fR92-R93): Added `autoComplete="off"` and `autoCorrect="off"` to the `TextInput` component.