### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
 	"packages/client": "5.4.1",
-	"packages/component": "5.3.4"
+	"packages/component": "5.3.5"
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.3.5](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.4...sassysaint-v5.3.5) (2024-10-20)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([28a1e79](https://github.com/versini-org/sassysaint-ui/commit/28a1e792af7e6239fafd0981df88d44dcc49fdf1))
+
 ## [5.3.4](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.3...sassysaint-v5.3.4) (2024-10-20)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.3.4",
+	"version": "5.3.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>sassysaint: 5.3.5</summary>

## [5.3.5](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.4...sassysaint-v5.3.5) (2024-10-20)


### Bug Fixes

* bump non-breaking dependencies to latest ([28a1e79](https://github.com/versini-org/sassysaint-ui/commit/28a1e792af7e6239fafd0981df88d44dcc49fdf1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).