### PR TITLE
fix(History): Panel width should not change on filter

### DIFF
--- a/packages/client/src/modules/History/History.tsx
+++ b/packages/client/src/modules/History/History.tsx
@@ -13,12 +13,7 @@ export const History = ({
 	open: boolean;
 }) => {
 	return (
-		<Panel
-			open={open}
-			onOpenChange={onOpenChange}
-			title={HISTORY_TITLE}
-			className="max-2-xl sm:max-w-4xl xl:max-w-5xl"
-		>
+		<Panel open={open} onOpenChange={onOpenChange} title={HISTORY_TITLE}>
 			<HistoryContent onOpenChange={onOpenChange} historyData={historyData} />
 		</Panel>
 	);


### PR DESCRIPTION
This pull request includes a small change to the `packages/client/src/modules/History/History.tsx` file. The change simplifies the `Panel` component by removing unnecessary class names.

* [`packages/client/src/modules/History/History.tsx`](diffhunk://#diff-c8c422f5fd628dd41e2ab98eb843994d656747afc717db0ee4b89f8b5c6b1be7L16-R16): Simplified the `Panel` component by removing the class names `max-2-xl`, `sm:max-w-4xl`, and `xl:max-w-5xl`.