### PR TITLE
fix(History): models are lost when deleting a chat

### DIFF
--- a/packages/client/src/common/services.ts
+++ b/packages/client/src/common/services.ts
@@ -39,6 +39,7 @@ export const GRAPHQL_QUERIES = {
 		deleteChat(id: $id, user: $userId) {
 			timestamp
 			id
+			model
 			messages {
 				content
 			}

--- a/packages/client/src/modules/History/HistoryTable.tsx
+++ b/packages/client/src/modules/History/HistoryTable.tsx
@@ -257,10 +257,10 @@ export const HistoryTable = ({
 								</TableCell>
 
 								<TableCell component="th" scope="row" className="text-gray-400">
-									{item.model.startsWith("claude") && (
+									{item.model && item.model.startsWith("claude") && (
 										<IconAnthropic className="size-4 sm:size-5" />
 									)}
-									{item.model.startsWith("gpt") && (
+									{item.model && item.model.startsWith("gpt") && (
 										<IconOpenAI className="size-4 sm:size-5" />
 									)}
 								</TableCell>


### PR DESCRIPTION
This pull request includes changes to the `packages/client` directory to enhance the handling of the `model` attribute in GraphQL queries and the HistoryTable component. The main improvements focus on adding a new field to the GraphQL query and ensuring the `model` attribute is properly checked before use.

Enhancements to GraphQL queries and HistoryTable component:

* [`packages/client/src/common/services.ts`](diffhunk://#diff-02cb936c5b52006a4b7785be3e28d2f195af5530202af1132586b3c6f40fc034R42): Added the `model` field to the `deleteChat` GraphQL query to include the model information in the response.
* [`packages/client/src/modules/History/HistoryTable.tsx`](diffhunk://#diff-a885c50f1faf1c52f3bd23c9e14f8f753aacd61bb8062f5bf2acb3ac7987ad5dL260-R263): Updated the HistoryTable component to check if the `model` attribute exists before calling `startsWith` to prevent potential errors.