### PR TITLE
feat: reset current chat when switching engines

### DIFF
--- a/packages/client/src/modules/Messages/LazyHeader.tsx
+++ b/packages/client/src/modules/Messages/LazyHeader.tsx
@@ -17,6 +17,7 @@ import { useContext, useEffect, useState } from "react";
 
 import {
 	ACTION_ENGINE,
+	ACTION_RESET,
 	DEFAULT_AI_ENGINE,
 	ENGINE_ANTHROPIC,
 	LOCAL_STORAGE_ENGINE_TOGGLE,
@@ -195,6 +196,9 @@ const LazyHeader = () => {
 													payload: {
 														engine: value,
 													},
+												});
+												dispatch({
+													type: ACTION_RESET,
 												});
 											} catch (_error) {
 												// nothing to declare officer


### PR DESCRIPTION
This pull request includes changes to the `packages/client/src/modules/Messages/LazyHeader.tsx` file. The primary goal of these changes is to add a new action type and ensure that the state is reset under certain conditions.

Key changes:

* Added `ACTION_RESET` to the list of imported action types.
* Dispatched the `ACTION_RESET` action within the `LazyHeader` component to reset the state after setting the engine value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new action type, `ACTION_RESET`, to enhance user experience when changing engine preferences in the `LazyHeader` component. 

- **Bug Fixes**
	- Improved state handling related to engine preference changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->