### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.4.3",
-	"packages/component": "5.3.7"
+	"packages/client": "5.5.0",
+	"packages/component": "5.3.8"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.5.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.4.3...client-v5.5.0) (2024-11-24)
+
+
+### Features
+
+* reset current chat when switching engines ([b433905](https://github.com/versini-org/sassysaint-ui/commit/b43390528ce8d68262c6eed635b12acebcb4f7e2))
+
 ## [5.4.3](https://github.com/versini-org/sassysaint-ui/compare/client-v5.4.2...client-v5.4.3) (2024-11-19)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.4.3",
+	"version": "5.5.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -4920,5 +4920,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.5.0": {
+    "Initial CSS": {
+      "fileSize": 72174,
+      "fileSizeGzip": 10509,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 241674,
+      "fileSizeGzip": 74053,
+      "limit": "73 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 66030,
+      "fileSizeGzip": 14376,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 157274,
+      "fileSizeGzip": 47187,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161967,
+      "fileSizeGzip": 45997,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442137,
+      "fileSizeGzip": 127662,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.3.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.7...sassysaint-v5.3.8) (2024-11-24)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.5.0
+
 ## [5.3.7](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.6...sassysaint-v5.3.7) (2024-11-19)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.3.7",
+	"version": "5.3.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.5.0</summary>

## [5.5.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.4.3...client-v5.5.0) (2024-11-24)


### Features

* reset current chat when switching engines ([b433905](https://github.com/versini-org/sassysaint-ui/commit/b43390528ce8d68262c6eed635b12acebcb4f7e2))
</details>

<details><summary>sassysaint: 5.3.8</summary>

## [5.3.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.7...sassysaint-v5.3.8) (2024-11-24)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.5.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).