### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
 		"@versini/dev-dependencies-client": "6.0.8",
 		"@versini/dev-dependencies-types": "1.3.10"
 	},
-	"packageManager": "pnpm@9.13.2+sha512.88c9c3864450350e65a33587ab801acf946d7c814ed1134da4a924f6df5a2120fd36b46aab68f7cd1d413149112d53c7db3a4136624cfd00ff1846a0c6cef48a"
+	"packageManager": "pnpm@9.14.3+sha512.c0f53ee99477ed969b82b289ad011a5d16bf1623c957e7f29eabe8d0c00b574c29b8c7f54f6c67ee710c73f285c8154d07ce44b46fe2c0eeb476a90441bac371"
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `package.json` file. The change updates the version of the package manager used in the project.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R17): Updated `packageManager` from `pnpm@9.13.2` to `pnpm@9.14.3` to ensure compatibility with the latest features and security updates.