### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -55,6 +55,6 @@
 		"rehype-katex": "7.0.1",
 		"remark-gfm": "4.0.0",
 		"remark-math": "6.0.0",
-		"uuid": "10.0.0"
+		"uuid": "11.0.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0
       uuid:
-        specifier: 10.0.0
-        version: 10.0.0
+        specifier: 11.0.3
+        version: 11.0.3
     devDependencies:
       '@versini/ui-styles':
         specifier: 1.11.1
@@ -5494,6 +5494,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@11.0.3:
+    resolution: {integrity: sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -12087,6 +12091,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.0.3: {}
 
   v8-compile-cache-lib@3.0.1:
     optional: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `uuid` dependency version to enhance performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->