### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.5.0",
-	"packages/component": "5.3.8"
+	"packages/client": "5.5.1",
+	"packages/component": "5.3.9"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.5.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.5.0...client-v5.5.1) (2024-11-28)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([79af735](https://github.com/versini-org/sassysaint-ui/commit/79af7358c7e82f00bbb22fcbf2e44b0f0cbf7e65))
+* bump non-breaking dependencies to latest ([5794eb7](https://github.com/versini-org/sassysaint-ui/commit/5794eb73fb41ad209ea7a5b1bda7184bdaa56192))
+* bump non-breaking dependencies to latest  ([79af735](https://github.com/versini-org/sassysaint-ui/commit/79af7358c7e82f00bbb22fcbf2e44b0f0cbf7e65))
+
 ## [5.5.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.4.3...client-v5.5.0) (2024-11-24)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.5.0",
+	"version": "5.5.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -4964,5 +4964,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.5.1": {
+    "Initial CSS": {
+      "fileSize": 72174,
+      "fileSizeGzip": 10509,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 241299,
+      "fileSizeGzip": 73904,
+      "limit": "73 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 66027,
+      "fileSizeGzip": 14424,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 158514,
+      "fileSizeGzip": 47437,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161967,
+      "fileSizeGzip": 45997,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442137,
+      "fileSizeGzip": 127662,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.3.9](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.8...sassysaint-v5.3.9) (2024-11-28)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.5.1
+
 ## [5.3.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.7...sassysaint-v5.3.8) (2024-11-24)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.3.8",
+	"version": "5.3.9",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.5.1</summary>

## [5.5.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.5.0...client-v5.5.1) (2024-11-28)


### Bug Fixes

* bump non-breaking dependencies to latest ([79af735](https://github.com/versini-org/sassysaint-ui/commit/79af7358c7e82f00bbb22fcbf2e44b0f0cbf7e65))
* bump non-breaking dependencies to latest ([5794eb7](https://github.com/versini-org/sassysaint-ui/commit/5794eb73fb41ad209ea7a5b1bda7184bdaa56192))
* bump non-breaking dependencies to latest  ([79af735](https://github.com/versini-org/sassysaint-ui/commit/79af7358c7e82f00bbb22fcbf2e44b0f0cbf7e65))
</details>

<details><summary>sassysaint: 5.3.9</summary>

## [5.3.9](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.8...sassysaint-v5.3.9) (2024-11-28)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.5.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).