### PR TITLE
fix: do not focus on input field when GPT is done streaming

### DIFF
--- a/packages/client/src/common/strings.ts
+++ b/packages/client/src/common/strings.ts
@@ -14,8 +14,14 @@ export const STATS = "Statistics";
 export const HISTORY_TITLE = "Chat history";
 export const ABOUT_TITLE = "About";
 export const TYPE_QUESTION = "Type your question here";
-export const CLEAR = "Clear chat";
-export const CANCEL = "Cancel chat";
+export const TOOLBOX = {
+	ACTION_WHILE_STREAMING: {
+		content: "Cancel chat",
+	},
+	ACTION_WHILE_NOT_STREAMING: {
+		content: "New chat",
+	},
+};
 export const NA = "N/A";
 export const TAGS_DESCRIPTION =
 	"Tags are pre-filled buttons available on the main screen, to help you quickly start requests. The label is used for the button, and the content is what will be inserted in the chat when the button is pressed.";

--- a/packages/client/src/modules/Messages/PromptInput.tsx
+++ b/packages/client/src/modules/Messages/PromptInput.tsx
@@ -57,7 +57,6 @@ export const PromptInput = () => {
 	const [userInput, setUserInput] = useState("");
 	const { getAccessToken, user } = useAuth();
 
-	const inputFocusedRef = useRef(false);
 	const inputRef: React.RefObject<HTMLTextAreaElement> = useRef(null);
 	const readerRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(
 		null,
@@ -211,24 +210,10 @@ export const PromptInput = () => {
 	};
 
 	/**
-	 * Focus on the input field when the chat is not streaming,
-	 * but only if it was not manually focused before.
+	 * If the user clicks on a tag, the content of the tag is placed in the
+	 * input field, the input field gets the focus, and we reset the tag
+	 * toggle status.
 	 */
-	useEffect(() => {
-		if (
-			state?.streaming === false &&
-			!inputFocusedRef.current &&
-			inputRef.current
-		) {
-			inputFocusedRef.current = true;
-			inputRef.current.focus();
-		}
-
-		if (state?.streaming === true && inputFocusedRef.current === true) {
-			inputFocusedRef.current = false;
-		}
-	}, [state]);
-
 	useEffect(() => {
 		if (tagsState.tag !== "") {
 			setUserInput(tagsState.tag);
@@ -238,6 +223,15 @@ export const PromptInput = () => {
 			});
 		}
 	}, [tagsState, tagsDispatch]);
+
+	/**
+	 * If the chat is reset, we focus the input field.
+	 */
+	useEffect(() => {
+		if (state && state.usage === 0 && state.messages.length === 0) {
+			inputRef.current && inputRef.current.focus();
+		}
+	}, [state]);
 
 	return (
 		<form className="mt-2" onSubmit={onSubmit}>

--- a/packages/client/src/modules/Toolbox/Toolbox.tsx
+++ b/packages/client/src/modules/Toolbox/Toolbox.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "@versini/auth-provider";
-import { Button } from "@versini/ui-button";
+import { Button, ButtonIcon } from "@versini/ui-button";
+import { IconClose, IconEdit } from "@versini/ui-icons";
 import { Flexgrid, FlexgridItem } from "@versini/ui-system";
 import { useContext, useEffect, useRef, useState } from "react";
 
@@ -10,11 +11,10 @@ import {
 	ROLE_ASSISTANT,
 } from "../../common/constants";
 import { SERVICE_TYPES, serviceCall } from "../../common/services";
-import { CANCEL, CLEAR } from "../../common/strings";
+import { TOOLBOX } from "../../common/strings";
+import type { Tag } from "../../common/types";
 import { isLastMessageFromRole } from "../../common/utilities";
 import { AppContext, TagsContext } from "../App/AppContext";
-
-import type { Tag } from "../../common/types";
 
 export const Toolbox = () => {
 	const { dispatch, state } = useContext(AppContext);
@@ -31,7 +31,7 @@ export const Toolbox = () => {
 	const buttonRef = useRef<HTMLButtonElement>(null);
 	const buttonFocusedRef = useRef(false);
 
-	const clearChat = (e: React.MouseEvent<HTMLButtonElement>) => {
+	const toolboxPrimaryAction = (e: React.MouseEvent<HTMLButtonElement>) => {
 		e.preventDefault();
 		dispatch({
 			type: ACTION_RESET,
@@ -54,6 +54,7 @@ export const Toolbox = () => {
 
 		if (state?.streaming === false) {
 			buttonFocusedRef.current = false;
+			buttonRef.current?.blur();
 		}
 	}, [state]);
 
@@ -145,15 +146,24 @@ export const Toolbox = () => {
 
 			{isLastMessageFromRole(ROLE_ASSISTANT, state) && (
 				<div className={toolboxClass}>
-					<Button
+					<ButtonIcon
 						noBorder
 						mode="dark"
 						focusMode="light"
 						ref={buttonRef}
-						onClick={clearChat}
+						onClick={toolboxPrimaryAction}
+						labelRight={
+							state?.streaming
+								? TOOLBOX.ACTION_WHILE_STREAMING.content
+								: TOOLBOX.ACTION_WHILE_NOT_STREAMING.content
+						}
 					>
-						{state?.streaming ? CANCEL : CLEAR}
-					</Button>
+						{state?.streaming ? (
+							<IconClose className="size-4" />
+						) : (
+							<IconEdit className="size-4" />
+						)}
+					</ButtonIcon>
 				</div>
 			)}
 		</>


### PR DESCRIPTION
This pull request includes several changes to the `packages/client` module, focusing on improving the user interface and refactoring the code for better readability and maintainability. The most important changes are grouped by theme as follows:

### Refactoring and Code Simplification:

* [`packages/client/src/modules/Messages/PromptInput.tsx`](diffhunk://#diff-9885c870752db45c27ad1d9e18339761c7d78d2e8b7433b8c60c319ca0bf2d44L60): Removed the `inputFocusedRef` reference and its associated logic, simplifying the `useEffect` hook that handles input focus behavior. [[1]](diffhunk://#diff-9885c870752db45c27ad1d9e18339761c7d78d2e8b7433b8c60c319ca0bf2d44L60) [[2]](diffhunk://#diff-9885c870752db45c27ad1d9e18339761c7d78d2e8b7433b8c60c319ca0bf2d44L214-L231)
* [`packages/client/src/modules/Messages/PromptInput.tsx`](diffhunk://#diff-9885c870752db45c27ad1d9e18339761c7d78d2e8b7433b8c60c319ca0bf2d44R227-R235): Added a new `useEffect` hook to focus the input field when the chat is reset.

### User Interface Improvements:

* [`packages/client/src/common/strings.ts`](diffhunk://#diff-32df5c915dba767265e27eb1cc7044c731c3732fdc2e3e9920ce2b32eeb4efd2L17-R24): Replaced `CLEAR` and `CANCEL` constants with a `TOOLBOX` object containing more descriptive action labels for different chat states.
* [`packages/client/src/modules/Toolbox/Toolbox.tsx`](diffhunk://#diff-2452db395be13752f78761d37e74ca8ddaefe270536419537ef843546d4920d7L13-L18): Updated the `Toolbox` component to use the new `TOOLBOX` object for action labels and replaced the `Button` component with `ButtonIcon` for better visual representation. [[1]](diffhunk://#diff-2452db395be13752f78761d37e74ca8ddaefe270536419537ef843546d4920d7L13-L18) [[2]](diffhunk://#diff-2452db395be13752f78761d37e74ca8ddaefe270536419537ef843546d4920d7L148-R166)

### Dependency Updates:

* [`packages/client/src/modules/Toolbox/Toolbox.tsx`](diffhunk://#diff-2452db395be13752f78761d37e74ca8ddaefe270536419537ef843546d4920d7L2-R3): Added imports for `ButtonIcon`, `IconClose`, and `IconEdit` from `@versini/ui-icons` to support the updated `Toolbox` component.