### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.6.0",
-	"packages/component": "5.3.11"
+	"packages/client": "5.6.1",
+	"packages/component": "5.3.12"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.6.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.0...client-v5.6.1) (2024-11-30)
+
+
+### Bug Fixes
+
+* app rename was not complete ([967ea48](https://github.com/versini-org/sassysaint-ui/commit/967ea48b772dbd9db04f400e78f883fd0f507631))
+
 ## [5.6.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.5.2...client-v5.6.0) (2024-11-30)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.6.0",
+	"version": "5.6.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -5096,5 +5096,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.6.1": {
+    "Initial CSS": {
+      "fileSize": 72369,
+      "fileSizeGzip": 10527,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 241347,
+      "fileSizeGzip": 73937,
+      "limit": "73 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 68442,
+      "fileSizeGzip": 15067,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 159171,
+      "fileSizeGzip": 47604,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161967,
+      "fileSizeGzip": 45997,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442137,
+      "fileSizeGzip": 127662,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.3.12](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.11...sassysaint-v5.3.12) (2024-11-30)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.6.1
+
 ## [5.3.11](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.10...sassysaint-v5.3.11) (2024-11-30)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.3.11",
+	"version": "5.3.12",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.6.1</summary>

## [5.6.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.0...client-v5.6.1) (2024-11-30)


### Bug Fixes

* app rename was not complete ([967ea48](https://github.com/versini-org/sassysaint-ui/commit/967ea48b772dbd9db04f400e78f883fd0f507631))
</details>

<details><summary>sassysaint: 5.3.12</summary>

## [5.3.12](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.11...sassysaint-v5.3.12) (2024-11-30)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.6.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).