### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.6.1",
-	"packages/component": "5.3.12"
+	"packages/client": "5.6.2",
+	"packages/component": "5.3.13"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.6.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.1...client-v5.6.2) (2024-12-01)
+
+
+### Bug Fixes
+
+* minor size update to title and sub-title ([3feed56](https://github.com/versini-org/sassysaint-ui/commit/3feed56a682c6d9c0b4845ca3392321cc607e17b))
+* Tags Panel footer is not reachable on devices ([740fce1](https://github.com/versini-org/sassysaint-ui/commit/740fce1d7227c034dc2ff6a33c76802884bcada8))
+* **Tags:** automatically adding an ending space if it's missing ([f0ad052](https://github.com/versini-org/sassysaint-ui/commit/f0ad052c30e1e2396d9015d6bb0e96f6491b02ea))
+
 ## [5.6.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.0...client-v5.6.1) (2024-11-30)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.6.1",
+	"version": "5.6.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -5140,5 +5140,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.6.2": {
+    "Initial CSS": {
+      "fileSize": 72487,
+      "fileSizeGzip": 10544,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 241366,
+      "fileSizeGzip": 73943,
+      "limit": "73 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 68495,
+      "fileSizeGzip": 15095,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 159156,
+      "fileSizeGzip": 47594,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161967,
+      "fileSizeGzip": 45997,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442137,
+      "fileSizeGzip": 127662,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.3.13](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.12...sassysaint-v5.3.13) (2024-12-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.6.2
+
 ## [5.3.12](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.11...sassysaint-v5.3.12) (2024-11-30)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.3.12",
+	"version": "5.3.13",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.6.2</summary>

## [5.6.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.1...client-v5.6.2) (2024-12-01)


### Bug Fixes

* minor size update to title and sub-title ([3feed56](https://github.com/versini-org/sassysaint-ui/commit/3feed56a682c6d9c0b4845ca3392321cc607e17b))
* Tags Panel footer is not reachable on devices ([740fce1](https://github.com/versini-org/sassysaint-ui/commit/740fce1d7227c034dc2ff6a33c76802884bcada8))
* **Tags:** automatically adding an ending space if it's missing ([f0ad052](https://github.com/versini-org/sassysaint-ui/commit/f0ad052c30e1e2396d9015d6bb0e96f6491b02ea))
</details>

<details><summary>sassysaint: 5.3.13</summary>

## [5.3.13](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.12...sassysaint-v5.3.13) (2024-12-01)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.6.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).