### PR TITLE
fix(Tags): automatically adding an ending space if it's missing

### DIFF
--- a/packages/client/src/modules/Messages/PromptInput.tsx
+++ b/packages/client/src/modules/Messages/PromptInput.tsx
@@ -216,7 +216,16 @@ export const PromptInput = () => {
 	 */
 	useEffect(() => {
 		if (tagsState.tag !== "") {
-			setUserInput(tagsState.tag);
+			/**
+			 * If the tag ends with a colon but does not ends with a space,
+			 * we add a space at the end.
+			 */
+			const newTag =
+				tagsState.tag.endsWith(":") && !tagsState.tag.endsWith(": ")
+					? tagsState.tag + " "
+					: tagsState.tag;
+
+			setUserInput(newTag);
 			inputRef.current && inputRef.current.focus();
 			tagsDispatch({
 				type: ACTION_RESET_TAGS,

--- a/packages/client/src/modules/Profile/Tags.tsx
+++ b/packages/client/src/modules/Profile/Tags.tsx
@@ -136,11 +136,7 @@ export const TagsPanel = ({
 				localTags.tags.map((tag: Tag) => (
 					<Card
 						key={`tag-slot-${tag.slot}`}
-						header={
-							tag.label !== ""
-								? `Tag ${tag.slot} - ${tag.label}`
-								: `Tag ${tag.slot}`
-						}
+						header={`Tag ${tag.slot + 1}`}
 						className="prose-dark dark:prose-lighter"
 						spacing={{ b: 2 }}
 					>


### PR DESCRIPTION
This pull request includes changes to improve the handling of tags in the `PromptInput` and `TagsPanel` components. The most important changes include adding a space after tags that end with a colon and simplifying the header display for tags.

Improvements to tag handling:

* [`packages/client/src/modules/Messages/PromptInput.tsx`](diffhunk://#diff-9885c870752db45c27ad1d9e18339761c7d78d2e8b7433b8c60c319ca0bf2d44L219-R228): Added logic to append a space to tags that end with a colon but not with a space to ensure proper formatting.

Simplification of tag display:

* [`packages/client/src/modules/Profile/Tags.tsx`](diffhunk://#diff-51a0e31f634d82555d0bbb79dd069a554bd2f912da7ebce420984fd82c893d21L139-R139): Simplified the header display for tags by incrementing the slot number directly in the header string.