### PR TITLE
chore: reorganize reducers for further planned refactor

### DIFF
--- a/packages/client/src/common/__tests__/appReducer.test.ts
+++ b/packages/client/src/common/__tests__/appReducer.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-
 import {
 	ACTION_MESSAGE,
 	ACTION_MODEL,
 	ACTION_RESET,
 	ACTION_RESTORE,
-} from "../../../common/constants";
-import { reducer } from "../reducer";
+} from "../constants";
+import { appReducer } from "../reducers/appReducer";
 
 const MOCK_UUIDV4 = "123456-7890-1234567890";
 
@@ -25,8 +24,10 @@ describe("Non-DOM tests", () => {
 				usage: 456,
 				messages: [],
 				isComponent: false,
+				engine: "",
+				tags: [],
 			};
-			expect(reducer(state, undefined)).toEqual(state);
+			expect(appReducer(state, undefined)).toEqual(state);
 		});
 
 		it("should return the payload state on ACTION_RESTORE", () => {
@@ -36,6 +37,8 @@ describe("Non-DOM tests", () => {
 				usage: 456,
 				messages: [],
 				isComponent: false,
+				engine: "",
+				tags: [],
 			};
 			const actionPayload = {
 				id: "123456",
@@ -50,7 +53,7 @@ describe("Non-DOM tests", () => {
 				],
 			};
 			expect(
-				reducer(state, {
+				appReducer(state, {
 					type: ACTION_RESTORE,
 					payload: actionPayload,
 				}),
@@ -64,6 +67,8 @@ describe("Non-DOM tests", () => {
 					},
 				],
 				isComponent: state.isComponent,
+				engine: state.engine,
+				tags: state.tags,
 			});
 		});
 
@@ -74,9 +79,11 @@ describe("Non-DOM tests", () => {
 				usage: 456,
 				messages: [],
 				isComponent: false,
+				engine: "",
+				tags: [],
 			};
 			expect(
-				reducer(state, {
+				appReducer(state, {
 					type: ACTION_RESET,
 				}),
 			).toEqual({
@@ -85,6 +92,8 @@ describe("Non-DOM tests", () => {
 				usage: 0,
 				messages: [],
 				isComponent: state.isComponent,
+				engine: state.engine,
+				tags: state.tags,
 			});
 		});
 
@@ -95,13 +104,15 @@ describe("Non-DOM tests", () => {
 				usage: 456,
 				messages: [],
 				isComponent: false,
+				engine: "",
+				tags: [],
 			};
 			const actionPayload = {
 				model: "gpt-777",
 				usage: 456789,
 			};
 			expect(
-				reducer(state, {
+				appReducer(state, {
 					type: ACTION_MODEL,
 					payload: actionPayload,
 				}),
@@ -111,6 +122,8 @@ describe("Non-DOM tests", () => {
 				usage: actionPayload.usage,
 				messages: state.messages,
 				isComponent: state.isComponent,
+				engine: state.engine,
+				tags: state.tags,
 			});
 		});
 
@@ -129,6 +142,8 @@ describe("Non-DOM tests", () => {
 					},
 				],
 				isComponent: false,
+				engine: "",
+				tags: [],
 			};
 			const actionPayload = {
 				message: {
@@ -138,7 +153,7 @@ describe("Non-DOM tests", () => {
 				},
 			};
 			expect(
-				reducer(state, {
+				appReducer(state, {
 					type: ACTION_MESSAGE,
 					payload: actionPayload,
 				}),
@@ -153,6 +168,8 @@ describe("Non-DOM tests", () => {
 					},
 				],
 				isComponent: state.isComponent,
+				engine: state.engine,
+				tags: state.tags,
 			});
 		});
 
@@ -171,6 +188,8 @@ describe("Non-DOM tests", () => {
 					},
 				],
 				isComponent: false,
+				engine: "",
+				tags: [],
 			};
 			const actionPayload = {
 				message: {
@@ -179,7 +198,7 @@ describe("Non-DOM tests", () => {
 				},
 			};
 			expect(
-				reducer(state, {
+				appReducer(state, {
 					type: ACTION_MESSAGE,
 					payload: actionPayload,
 				}),
@@ -194,6 +213,8 @@ describe("Non-DOM tests", () => {
 					},
 				],
 				isComponent: state.isComponent,
+				engine: state.engine,
+				tags: state.tags,
 			});
 		});
 	});

--- a/packages/client/src/common/reducers/appReducer.ts
+++ b/packages/client/src/common/reducers/appReducer.ts
@@ -5,59 +5,13 @@ import {
 	ACTION_MESSAGE,
 	ACTION_MODEL,
 	ACTION_RESET,
-	ACTION_RESET_TAGS,
 	ACTION_RESTORE,
-	ACTION_SEARCH,
-	ACTION_SET_TAGS,
-	ACTION_SORT,
 	ACTION_STREAMING,
-	ACTION_TOGGLE_TAG,
 	ROLE_ASSISTANT,
-} from "../../common/constants";
-import { ActionProps, StateProps } from "../../common/types";
+} from "../constants";
+import type { ActionProps, StateProps } from "../types";
 
-export const tagsReducer = (state: any, action: any) => {
-	if (action?.type === ACTION_TOGGLE_TAG) {
-		return {
-			tags: state.tags,
-			tag: action.payload.tag,
-		};
-	}
-	if (action?.type === ACTION_RESET_TAGS) {
-		return {
-			tags: state.tags,
-			tag: "",
-		};
-	}
-	if (action?.type === ACTION_SET_TAGS) {
-		return {
-			tags: action.payload.tags,
-			tag: "",
-		};
-	}
-	return state;
-};
-
-export const historyReducer = (state: any, action: any) => {
-	if (action?.type === ACTION_SEARCH) {
-		return {
-			searchString: action.payload.searchString,
-			sortedCell: state.sortedCell,
-			sortDirection: state.sortDirection,
-		};
-	}
-
-	if (action?.type === ACTION_SORT) {
-		return {
-			searchString: state.searchString,
-			sortedCell: action.payload.sortedCell,
-			sortDirection: action.payload.sortDirection,
-		};
-	}
-	return state;
-};
-
-export const reducer = (state: StateProps, action: ActionProps) => {
+export const appReducer = (state: StateProps, action: ActionProps) => {
 	if (action?.type === ACTION_RESTORE) {
 		const messages = action.payload.messages.map((item: any) => {
 			return {

--- a/packages/client/src/common/reducers/historyReducer.ts
+++ b/packages/client/src/common/reducers/historyReducer.ts
@@ -1,0 +1,25 @@
+import { ACTION_SEARCH, ACTION_SORT } from "../constants";
+import type { ActionHistoryProps, StateHistoryProps } from "../types";
+
+export const historyReducer = (
+	state: StateHistoryProps,
+	action: ActionHistoryProps,
+) => {
+	switch (action?.type) {
+		case ACTION_SEARCH:
+			return {
+				searchString: action.payload.searchString,
+				sortedCell: state.sortedCell,
+				sortDirection: state.sortDirection,
+			};
+		case ACTION_SORT:
+			return {
+				searchString: state.searchString,
+				sortedCell: action.payload.sortedCell,
+				sortDirection: action.payload.sortDirection,
+			};
+
+		default:
+			return state;
+	}
+};

--- a/packages/client/src/common/reducers/tagsReducer.ts
+++ b/packages/client/src/common/reducers/tagsReducer.ts
@@ -1,0 +1,29 @@
+import {
+	ACTION_RESET_TAGS,
+	ACTION_SET_TAGS,
+	ACTION_TOGGLE_TAG,
+} from "../constants";
+import type { ActionTagsProps, StateTagsProps } from "../types";
+
+export const tagsReducer = (state: StateTagsProps, action: ActionTagsProps) => {
+	switch (action?.type) {
+		case ACTION_TOGGLE_TAG:
+			return {
+				tags: state.tags,
+				tag: action.payload.tag,
+			};
+		case ACTION_RESET_TAGS:
+			return {
+				tags: state.tags,
+				tag: "",
+			};
+		case ACTION_SET_TAGS:
+			return {
+				tags: action.payload.tags,
+				tag: "",
+			};
+
+		default:
+			return state;
+	}
+};

--- a/packages/client/src/common/types.d.ts
+++ b/packages/client/src/common/types.d.ts
@@ -4,8 +4,13 @@ import {
 	ACTION_MESSAGE,
 	ACTION_MODEL,
 	ACTION_RESET,
+	ACTION_RESET_TAGS,
 	ACTION_RESTORE,
+	ACTION_SEARCH,
+	ACTION_SET_TAGS,
+	ACTION_SORT,
 	ACTION_STREAMING,
+	ACTION_TOGGLE_TAG,
 } from "./constants";
 
 export type GeoLocation = {
@@ -106,3 +111,48 @@ export type Tag = {
 	label: string;
 	content: string;
 };
+
+export type StateTagsProps = {
+	tag: string;
+	tags: Tag[];
+};
+
+export type ActionTagsProps =
+	| undefined
+	| {
+			payload: {
+				tag: string;
+			};
+			type: typeof ACTION_TOGGLE_TAG;
+	  }
+	| {
+			type: typeof ACTION_RESET_TAGS;
+	  }
+	| {
+			payload: {
+				tags: Tag[];
+			};
+			type: typeof ACTION_SET_TAGS;
+	  };
+
+export type StateHistoryProps = {
+	searchString: string;
+	sortedCell: string;
+	sortDirection: string;
+};
+
+export type ActionHistoryProps =
+	| undefined
+	| {
+			payload: {
+				searchString: string;
+			};
+			type: typeof ACTION_SEARCH;
+	  }
+	| {
+			payload: {
+				sortedCell: string;
+				sortDirection: string;
+			};
+			type: typeof ACTION_SORT;
+	  };

--- a/packages/client/src/modules/App/LazyApp.tsx
+++ b/packages/client/src/modules/App/LazyApp.tsx
@@ -12,12 +12,14 @@ import {
 	LOCAL_STORAGE_SEARCH,
 	LOCAL_STORAGE_SORT,
 } from "../../common/constants";
+import { appReducer } from "../../common/reducers/appReducer";
+import { historyReducer } from "../../common/reducers/historyReducer";
+import { tagsReducer } from "../../common/reducers/tagsReducer";
 import { SERVICE_TYPES, serviceCall } from "../../common/services";
 import type { ServerStatsProps } from "../../common/types";
 import { AppFooter } from "../Footer/AppFooter";
 import { MessagesContainer } from "../Messages/MessagesContainer";
 import { AppContext, HistoryContext, TagsContext } from "./AppContext";
-import { historyReducer, reducer, tagsReducer } from "./reducer";
 
 function App({ isComponent = false }: { isComponent?: boolean }) {
 	const loadingServerStatsRef = useRef(false);
@@ -31,7 +33,7 @@ function App({ isComponent = false }: { isComponent?: boolean }) {
 		initialValue: TableCellSortDirections.ASC,
 	});
 
-	const [state, dispatch] = useReducer(reducer, {
+	const [state, dispatch] = useReducer(appReducer, {
 		id: uuidv4(),
 		model: DEFAULT_AI_ENGINE,
 		engine: DEFAULT_AI_ENGINE,
@@ -47,6 +49,7 @@ function App({ isComponent = false }: { isComponent?: boolean }) {
 	});
 	const [stateTags, dispatchTags] = useReducer(tagsReducer, {
 		tag: "",
+		tags: [],
 	});
 
 	const [serverStats, setServerStats] = useState<ServerStatsProps>({


### PR DESCRIPTION
This pull request involves significant refactoring and reorganization of the reducer files, as well as updates to the corresponding test files. The main changes include renaming and splitting the reducer files, updating the imports, and ensuring the tests align with the new structure.

### Refactoring and Reorganization:

* **File Renaming and Import Updates:**
  * `packages/client/src/modules/App/reducer.ts` was renamed to `packages/client/src/common/reducers/appReducer.ts` and the import paths were updated accordingly.
  * `packages/client/src/modules/App/__tests__/reducer.test.ts` was renamed to `packages/client/src/common/__tests__/appReducer.test.ts` and the import paths were updated accordingly.

* **Reducer Splitting:**
  * The `tagsReducer` and `historyReducer` were moved to their own files `packages/client/src/common/reducers/tagsReducer.ts` and `packages/client/src/common/reducers/historyReducer.ts` respectively. [[1]](diffhunk://#diff-bf1e1c71490ee9f3739d9cb1fa45a9ab224749fa2e1c1ecafb6202a3c1806a58R1-R25) [[2]](diffhunk://#diff-85ada6e13b51f52201873b6a4b8fbea5ffbdd0f58e2304b781b409c0afe8ab0aR1-R29)

### Test Updates:

* **Test Adjustments:**
  * Updated tests in `packages/client/src/common/__tests__/appReducer.test.ts` to use `appReducer` instead of the old `reducer`. This includes changes in multiple test cases to ensure they reference the new reducer and include additional state properties `engine` and `tags`. [[1]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R27-R30) [[2]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R40-R41) [[3]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8L53-R56) [[4]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R70-R71) [[5]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R82-R86) [[6]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R95-R96) [[7]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R107-R115) [[8]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R125-R126) [[9]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R145-R146) [[10]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8L141-R156) [[11]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R171-R172) [[12]](diffhunk://#diff-ddf4d171481ada3dc824ba4c659ed1dbda2ad81f006ef4d237a2f482e75bb1b8R191-R192)

### Application Code Updates:

* **Component Updates:**
  * Updated `LazyApp.tsx` to use the new `appReducer`, `historyReducer`, and `tagsReducer` imports from their new locations. [[1]](diffhunk://#diff-d892f4595875744e93063ce6ee05451392c8e0653a0564b99f936dbb2af8f165R15-L20) [[2]](diffhunk://#diff-d892f4595875744e93063ce6ee05451392c8e0653a0564b99f936dbb2af8f165L34-R36) [[3]](diffhunk://#diff-d892f4595875744e93063ce6ee05451392c8e0653a0564b99f936dbb2af8f165R52)