### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.6.4",
-	"packages/component": "5.3.15"
+	"packages/client": "5.6.5",
+	"packages/component": "5.3.16"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.6.5](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.4...client-v5.6.5) (2024-12-13)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest + build on node 22 ([04b9153](https://github.com/versini-org/sassysaint-ui/commit/04b91534a0432e07760031d2a2376d687cc2d8f9))
+
 ## [5.6.4](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.3...client-v5.6.4) (2024-12-12)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.6.4",
+	"version": "5.6.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.3.16](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.15...sassysaint-v5.3.16) (2024-12-13)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest + build on node 22 ([04b9153](https://github.com/versini-org/sassysaint-ui/commit/04b91534a0432e07760031d2a2376d687cc2d8f9))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.6.5
+
 ## [5.3.15](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.14...sassysaint-v5.3.15) (2024-12-12)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.3.15",
+	"version": "5.3.16",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.6.5</summary>

## [5.6.5](https://github.com/versini-org/sassysaint-ui/compare/client-v5.6.4...client-v5.6.5) (2024-12-13)


### Bug Fixes

* bump non-breaking dependencies to latest + build on node 22 ([04b9153](https://github.com/versini-org/sassysaint-ui/commit/04b91534a0432e07760031d2a2376d687cc2d8f9))
</details>

<details><summary>sassysaint: 5.3.16</summary>

## [5.3.16](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.3.15...sassysaint-v5.3.16) (2024-12-13)


### Bug Fixes

* bump non-breaking dependencies to latest + build on node 22 ([04b9153](https://github.com/versini-org/sassysaint-ui/commit/04b91534a0432e07760031d2a2376d687cc2d8f9))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.6.5
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).