### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.8.1",
-	"packages/component": "5.4.4"
+	"packages/client": "5.8.2",
+	"packages/component": "5.4.5"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.8.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.8.1...client-v5.8.2) (2024-12-27)
+
+
+### Bug Fixes
+
+* debounce search action in history by 200ms ([#698](https://github.com/versini-org/sassysaint-ui/issues/698)) ([c97d77a](https://github.com/versini-org/sassysaint-ui/commit/c97d77aa3882c939d3d6c879b9f3a989ae5dae24))
+* filtering history data is not taking timestamp into account ([#697](https://github.com/versini-org/sassysaint-ui/issues/697)) ([03a23dd](https://github.com/versini-org/sassysaint-ui/commit/03a23dd66509fd718393cd50821c8845278fe9f5))
+
 ## [5.8.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.8.0...client-v5.8.1) (2024-12-27)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.8.1",
+	"version": "5.8.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -5492,5 +5492,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.8.2": {
+    "Initial CSS": {
+      "fileSize": 72453,
+      "fileSizeGzip": 10556,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 283540,
+      "fileSizeGzip": 86549,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 69635,
+      "fileSizeGzip": 14969,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 160478,
+      "fileSizeGzip": 47443,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 162102,
+      "fileSizeGzip": 45961,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442131,
+      "fileSizeGzip": 127652,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.4.5](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.4...sassysaint-v5.4.5) (2024-12-27)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.8.2
+
 ## [5.4.4](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.3...sassysaint-v5.4.4) (2024-12-27)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.4.4",
+	"version": "5.4.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.8.2</summary>

## [5.8.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.8.1...client-v5.8.2) (2024-12-27)


### Bug Fixes

* debounce search action in history by 200ms ([#698](https://github.com/versini-org/sassysaint-ui/issues/698)) ([c97d77a](https://github.com/versini-org/sassysaint-ui/commit/c97d77aa3882c939d3d6c879b9f3a989ae5dae24))
* filtering history data is not taking timestamp into account ([#697](https://github.com/versini-org/sassysaint-ui/issues/697)) ([03a23dd](https://github.com/versini-org/sassysaint-ui/commit/03a23dd66509fd718393cd50821c8845278fe9f5))
</details>

<details><summary>sassysaint: 5.4.5</summary>

## [5.4.5](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.4...sassysaint-v5.4.5) (2024-12-27)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.8.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).