### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.10.0",
-	"packages/component": "5.4.7"
+	"packages/client": "5.10.1",
+	"packages/component": "5.4.8"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.10.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.10.0...client-v5.10.1) (2024-12-30)
+
+
+### Bug Fixes
+
+* bump breaking dependencies to latest ([#705](https://github.com/versini-org/sassysaint-ui/issues/705)) ([17f4514](https://github.com/versini-org/sassysaint-ui/commit/17f45145f5a3114a01bac94913c1d137938b0d48))
+* **History:** truncating message on the server instead of the client ([#707](https://github.com/versini-org/sassysaint-ui/issues/707)) ([1b4bd62](https://github.com/versini-org/sassysaint-ui/commit/1b4bd62ebf800bee1c6a51debd345072552d3dc7))
+
 ## [5.10.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.9.0...client-v5.10.0) (2024-12-28)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.10.0",
+	"version": "5.10.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -5624,5 +5624,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.10.1": {
+    "Initial CSS": {
+      "fileSize": 72323,
+      "fileSizeGzip": 10100,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 281357,
+      "fileSizeGzip": 86222,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 70720,
+      "fileSizeGzip": 15055,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 156107,
+      "fileSizeGzip": 46030,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161591,
+      "fileSizeGzip": 45834,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 442131,
+      "fileSizeGzip": 127652,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.4.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.7...sassysaint-v5.4.8) (2024-12-30)
+
+
+### Bug Fixes
+
+* bump breaking dependencies to latest ([#705](https://github.com/versini-org/sassysaint-ui/issues/705)) ([17f4514](https://github.com/versini-org/sassysaint-ui/commit/17f45145f5a3114a01bac94913c1d137938b0d48))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.10.1
+
 ## [5.4.7](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.6...sassysaint-v5.4.7) (2024-12-28)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.4.7",
+	"version": "5.4.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.10.1</summary>

## [5.10.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.10.0...client-v5.10.1) (2024-12-30)


### Bug Fixes

* bump breaking dependencies to latest ([#705](https://github.com/versini-org/sassysaint-ui/issues/705)) ([17f4514](https://github.com/versini-org/sassysaint-ui/commit/17f45145f5a3114a01bac94913c1d137938b0d48))
* **History:** truncating message on the server instead of the client ([#707](https://github.com/versini-org/sassysaint-ui/issues/707)) ([1b4bd62](https://github.com/versini-org/sassysaint-ui/commit/1b4bd62ebf800bee1c6a51debd345072552d3dc7))
</details>

<details><summary>sassysaint: 5.4.8</summary>

## [5.4.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.7...sassysaint-v5.4.8) (2024-12-30)


### Bug Fixes

* bump breaking dependencies to latest ([#705](https://github.com/versini-org/sassysaint-ui/issues/705)) ([17f4514](https://github.com/versini-org/sassysaint-ui/commit/17f45145f5a3114a01bac94913c1d137938b0d48))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.10.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).