### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.10.2",
-	"packages/component": "5.4.9"
+	"packages/client": "5.11.0",
+	"packages/component": "5.4.10"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [5.11.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.10.2...client-v5.11.0) (2024-12-30)
+
+
+### Features
+
+* adding capability to copy code snippets to clipboard ([#710](https://github.com/versini-org/sassysaint-ui/issues/710)) ([a04f2c8](https://github.com/versini-org/sassysaint-ui/commit/a04f2c86f2e2f5acc44d2e70742d4c5f7f675b28))
+
+
+### Bug Fixes
+
+* adding missing prod dependency ([#712](https://github.com/versini-org/sassysaint-ui/issues/712)) ([abfe84f](https://github.com/versini-org/sassysaint-ui/commit/abfe84fb684a4b792f05bfbcec05a19d56980987))
+
 ## [5.10.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.10.1...client-v5.10.2) (2024-12-30)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.10.2",
+	"version": "5.11.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -5712,5 +5712,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.11.0": {
+    "Initial CSS": {
+      "fileSize": 72352,
+      "fileSizeGzip": 10102,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 281357,
+      "fileSizeGzip": 86229,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 70916,
+      "fileSizeGzip": 15070,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 156382,
+      "fileSizeGzip": 46072,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161591,
+      "fileSizeGzip": 45834,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445589,
+      "fileSizeGzip": 128751,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.4.10](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.9...sassysaint-v5.4.10) (2024-12-30)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.11.0
+
 ## [5.4.9](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.8...sassysaint-v5.4.9) (2024-12-30)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.4.9",
+	"version": "5.4.10",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.11.0</summary>

## [5.11.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.10.2...client-v5.11.0) (2024-12-30)


### Features

* adding capability to copy code snippets to clipboard ([#710](https://github.com/versini-org/sassysaint-ui/issues/710)) ([a04f2c8](https://github.com/versini-org/sassysaint-ui/commit/a04f2c86f2e2f5acc44d2e70742d4c5f7f675b28))


### Bug Fixes

* adding missing prod dependency ([#712](https://github.com/versini-org/sassysaint-ui/issues/712)) ([abfe84f](https://github.com/versini-org/sassysaint-ui/commit/abfe84fb684a4b792f05bfbcec05a19d56980987))
</details>

<details><summary>sassysaint: 5.4.10</summary>

## [5.4.10](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.9...sassysaint-v5.4.10) (2024-12-30)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.11.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).