### PR TITLE
fix: pressing ENTER in search field should not trigger reset

### DIFF
--- a/packages/client/src/modules/History/HistoryContent.tsx
+++ b/packages/client/src/modules/History/HistoryContent.tsx
@@ -168,6 +168,7 @@ export const HistoryContent = ({ onOpenChange }: HistoryContentProps) => {
 							{...(historyState.searchString && {
 								rightElement: (
 									<Button
+										type="button"
 										disabled={!historyState.searchString}
 										mode="light"
 										focusMode="light"


### PR DESCRIPTION
This pull request includes a minor change to the `HistoryContent` component in the `HistoryContent.tsx` file. The change involves adding a `type="button"` attribute to a `Button` element within the component.

* [`packages/client/src/modules/History/HistoryContent.tsx`](diffhunk://#diff-1e332737525e48a576e60868e907180090ef00dede671deafc81fc477449801fR171): Added `type="button"` attribute to a `Button` element inside the `HistoryContent` component.