### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.11.0",
-	"packages/component": "5.4.10"
+	"packages/client": "5.11.1",
+	"packages/component": "5.4.11"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.11.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.11.0...client-v5.11.1) (2024-12-30)
+
+
+### Bug Fixes
+
+* pressing ENTER in search field should not trigger reset ([#713](https://github.com/versini-org/sassysaint-ui/issues/713)) ([fc55642](https://github.com/versini-org/sassysaint-ui/commit/fc5564263d273eb11925c1ff7c053ede2be279e8))
+
 ## [5.11.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.10.2...client-v5.11.0) (2024-12-30)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.11.0",
+	"version": "5.11.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -5756,5 +5756,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.11.1": {
+    "Initial CSS": {
+      "fileSize": 72352,
+      "fileSizeGzip": 10102,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 281357,
+      "fileSizeGzip": 86230,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 70916,
+      "fileSizeGzip": 15070,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 156396,
+      "fileSizeGzip": 46076,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161591,
+      "fileSizeGzip": 45834,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445589,
+      "fileSizeGzip": 128751,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.4.11](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.10...sassysaint-v5.4.11) (2024-12-30)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.11.1
+
 ## [5.4.10](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.9...sassysaint-v5.4.10) (2024-12-30)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.4.10",
+	"version": "5.4.11",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.11.1</summary>

## [5.11.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.11.0...client-v5.11.1) (2024-12-30)


### Bug Fixes

* pressing ENTER in search field should not trigger reset ([#713](https://github.com/versini-org/sassysaint-ui/issues/713)) ([fc55642](https://github.com/versini-org/sassysaint-ui/commit/fc5564263d273eb11925c1ff7c053ede2be279e8))
</details>

<details><summary>sassysaint: 5.4.11</summary>

## [5.4.11](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.10...sassysaint-v5.4.11) (2024-12-30)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.11.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).