### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.11.3",
-	"packages/component": "5.4.13"
+	"packages/client": "5.11.4",
+	"packages/component": "5.4.14"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.11.4](https://github.com/versini-org/sassysaint-ui/compare/client-v5.11.3...client-v5.11.4) (2024-12-31)
+
+
+### Bug Fixes
+
+* move "copy code" button above code block ([#720](https://github.com/versini-org/sassysaint-ui/issues/720)) ([195236c](https://github.com/versini-org/sassysaint-ui/commit/195236cf140f7e13a6d0ebe9aac7f100157fa855))
+
 ## [5.11.3](https://github.com/versini-org/sassysaint-ui/compare/client-v5.11.2...client-v5.11.3) (2024-12-31)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.11.3",
+	"version": "5.11.4",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -5888,5 +5888,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.11.4": {
+    "Initial CSS": {
+      "fileSize": 72312,
+      "fileSizeGzip": 10097,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 281292,
+      "fileSizeGzip": 86239,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 70807,
+      "fileSizeGzip": 15118,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 156176,
+      "fileSizeGzip": 46131,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161592,
+      "fileSizeGzip": 45838,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445974,
+      "fileSizeGzip": 128837,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.4.14](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.13...sassysaint-v5.4.14) (2024-12-31)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.11.4
+
 ## [5.4.13](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.12...sassysaint-v5.4.13) (2024-12-31)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.4.13",
+	"version": "5.4.14",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.11.4</summary>

## [5.11.4](https://github.com/versini-org/sassysaint-ui/compare/client-v5.11.3...client-v5.11.4) (2024-12-31)


### Bug Fixes

* move "copy code" button above code block ([#720](https://github.com/versini-org/sassysaint-ui/issues/720)) ([195236c](https://github.com/versini-org/sassysaint-ui/commit/195236cf140f7e13a6d0ebe9aac7f100157fa855))
</details>

<details><summary>sassysaint: 5.4.14</summary>

## [5.4.14](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.4.13...sassysaint-v5.4.14) (2024-12-31)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.11.4
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).