### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.14.0",
-	"packages/component": "5.5.1"
+	"packages/client": "5.14.1",
+	"packages/component": "5.5.2"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.14.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.14.0...client-v5.14.1) (2025-01-01)
+
+
+### Bug Fixes
+
+* minor layout update for the logo ([#728](https://github.com/versini-org/sassysaint-ui/issues/728)) ([f40e28e](https://github.com/versini-org/sassysaint-ui/commit/f40e28eb1fb30ebb626c58c3def825eef0d04365))
+* remove debug code that went to prod by mistake ([#730](https://github.com/versini-org/sassysaint-ui/issues/730)) ([767484e](https://github.com/versini-org/sassysaint-ui/commit/767484e2f338810b4519fdbe53b396283f88b967))
+
 ## [5.14.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.13.0...client-v5.14.0) (2025-01-01)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.14.0",
+	"version": "5.14.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -6064,5 +6064,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.14.1": {
+    "Initial CSS": {
+      "fileSize": 73135,
+      "fileSizeGzip": 10165,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 278970,
+      "fileSizeGzip": 85510,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 71666,
+      "fileSizeGzip": 15224,
+      "limit": "15 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 159267,
+      "fileSizeGzip": 47024,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161592,
+      "fileSizeGzip": 45838,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445974,
+      "fileSizeGzip": 128837,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.5.2](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.1...sassysaint-v5.5.2) (2025-01-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.14.1
+
 ## [5.5.1](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.0...sassysaint-v5.5.1) (2025-01-01)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.5.1",
+	"version": "5.5.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.14.1</summary>

## [5.14.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.14.0...client-v5.14.1) (2025-01-01)


### Bug Fixes

* minor layout update for the logo ([#728](https://github.com/versini-org/sassysaint-ui/issues/728)) ([f40e28e](https://github.com/versini-org/sassysaint-ui/commit/f40e28eb1fb30ebb626c58c3def825eef0d04365))
* remove debug code that went to prod by mistake ([#730](https://github.com/versini-org/sassysaint-ui/issues/730)) ([767484e](https://github.com/versini-org/sassysaint-ui/commit/767484e2f338810b4519fdbe53b396283f88b967))
</details>

<details><summary>sassysaint: 5.5.2</summary>

## [5.5.2](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.1...sassysaint-v5.5.2) (2025-01-01)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.14.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).