### PR TITLE
fix: remove debug code that went to prod by mistake

### DIFF
--- a/packages/client/src/modules/Messages/PromptInput.tsx
+++ b/packages/client/src/modules/Messages/PromptInput.tsx
@@ -5,7 +5,6 @@ import { TextArea } from "@versini/ui-textarea";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
-import { IconClose } from "@versini/ui-icons";
 import {
 	ACTION_MESSAGE,
 	ACTION_MODEL,
@@ -259,7 +258,6 @@ export const PromptInput = () => {
 
 	return (
 		<>
-			{state?.streaming ? <IconClose size="size-4" /> : null}
 			<form className="mt-2" onSubmit={onSubmit}>
 				<TextArea
 					mode="dark"


### PR DESCRIPTION
This pull request includes a few small changes to the `PromptInput.tsx` file. The changes involve removing an unused import and a conditional rendering of an icon.

Changes in `PromptInput.tsx`:

* Removed the import of `IconClose` from `@versini/ui-icons` as it is no longer used.
* Removed the conditional rendering of the `IconClose` component within the `PromptInput` component.