### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.16.1",
-	"packages/component": "5.5.5"
+	"packages/client": "5.16.2",
+	"packages/component": "5.5.6"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.16.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.16.1...client-v5.16.2) (2025-01-01)
+
+
+### Bug Fixes
+
+* isMobile was really for iPhone 16 pro ([#739](https://github.com/versini-org/sassysaint-ui/issues/739)) ([20a36d1](https://github.com/versini-org/sassysaint-ui/commit/20a36d102af08deb41b8b4302314c50380456226))
+
 ## [5.16.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.16.0...client-v5.16.1) (2025-01-01)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.16.1",
+	"version": "5.16.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -6240,5 +6240,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.16.2": {
+    "Initial CSS": {
+      "fileSize": 73642,
+      "fileSizeGzip": 10281,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 278970,
+      "fileSizeGzip": 85510,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 74506,
+      "fileSizeGzip": 15903,
+      "limit": "17 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 159919,
+      "fileSizeGzip": 47087,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161486,
+      "fileSizeGzip": 45783,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445974,
+      "fileSizeGzip": 128837,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.5.6](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.5...sassysaint-v5.5.6) (2025-01-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.16.2
+
 ## [5.5.5](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.4...sassysaint-v5.5.5) (2025-01-01)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.5.5",
+	"version": "5.5.6",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.16.2</summary>

## [5.16.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.16.1...client-v5.16.2) (2025-01-01)


### Bug Fixes

* isMobile was really for iPhone 16 pro ([#739](https://github.com/versini-org/sassysaint-ui/issues/739)) ([20a36d1](https://github.com/versini-org/sassysaint-ui/commit/20a36d102af08deb41b8b4302314c50380456226))
</details>

<details><summary>sassysaint: 5.5.6</summary>

## [5.5.6](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.5...sassysaint-v5.5.6) (2025-01-01)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.16.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).