### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.17.0",
-	"packages/component": "5.5.7"
+	"packages/client": "5.17.1",
+	"packages/component": "5.5.8"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.17.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.17.0...client-v5.17.1) (2025-01-02)
+
+
+### Bug Fixes
+
+* new name - take 2 ([#743](https://github.com/versini-org/sassysaint-ui/issues/743)) ([e4e4a3f](https://github.com/versini-org/sassysaint-ui/commit/e4e4a3f0b198ed9d34c112f9caffc0a8e61fcc90))
+
 ## [5.17.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.16.2...client-v5.17.0) (2025-01-02)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.17.0",
+	"version": "5.17.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -6328,5 +6328,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.17.1": {
+    "Initial CSS": {
+      "fileSize": 73642,
+      "fileSizeGzip": 10281,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 278972,
+      "fileSizeGzip": 85509,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 74506,
+      "fileSizeGzip": 15903,
+      "limit": "17 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 159919,
+      "fileSizeGzip": 47089,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161486,
+      "fileSizeGzip": 45783,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445974,
+      "fileSizeGzip": 128837,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.5.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.7...sassysaint-v5.5.8) (2025-01-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.17.1
+
 ## [5.5.7](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.6...sassysaint-v5.5.7) (2025-01-02)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.5.7",
+	"version": "5.5.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.17.1</summary>

## [5.17.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.17.0...client-v5.17.1) (2025-01-02)


### Bug Fixes

* new name - take 2 ([#743](https://github.com/versini-org/sassysaint-ui/issues/743)) ([e4e4a3f](https://github.com/versini-org/sassysaint-ui/commit/e4e4a3f0b198ed9d34c112f9caffc0a8e61fcc90))
</details>

<details><summary>sassysaint: 5.5.8</summary>

## [5.5.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.7...sassysaint-v5.5.8) (2025-01-02)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.17.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).