### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.17.1",
-	"packages/component": "5.5.8"
+	"packages/client": "5.18.0",
+	"packages/component": "5.5.9"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.18.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.17.1...client-v5.18.0) (2025-01-02)
+
+
+### Features
+
+* moving chat details into profile panel and settings panel standalone ([#745](https://github.com/versini-org/sassysaint-ui/issues/745)) ([9a51a5b](https://github.com/versini-org/sassysaint-ui/commit/9a51a5bd9c1becdf340d60f5183f44a3b742f106))
+
 ## [5.17.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.17.0...client-v5.17.1) (2025-01-02)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.17.1",
+	"version": "5.18.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.5.9](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.8...sassysaint-v5.5.9) (2025-01-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.18.0
+
 ## [5.5.8](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.7...sassysaint-v5.5.8) (2025-01-02)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.5.8",
+	"version": "5.5.9",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.18.0</summary>

## [5.18.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.17.1...client-v5.18.0) (2025-01-02)


### Features

* moving chat details into profile panel and settings panel standalone ([#745](https://github.com/versini-org/sassysaint-ui/issues/745)) ([9a51a5b](https://github.com/versini-org/sassysaint-ui/commit/9a51a5bd9c1becdf340d60f5183f44a3b742f106))
</details>

<details><summary>sassysaint: 5.5.9</summary>

## [5.5.9](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.8...sassysaint-v5.5.9) (2025-01-02)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.18.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).