### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.18.0",
-	"packages/component": "5.5.9"
+	"packages/client": "5.18.1",
+	"packages/component": "5.5.10"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.18.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.18.0...client-v5.18.1) (2025-01-02)
+
+
+### Bug Fixes
+
+* better variant color for passkey login button ([#749](https://github.com/versini-org/sassysaint-ui/issues/749)) ([9eba73f](https://github.com/versini-org/sassysaint-ui/commit/9eba73f6150a47bdc6f9ee8705ca64741b679ded))
+* minor refactor - mostly extracting header toolbar ([#747](https://github.com/versini-org/sassysaint-ui/issues/747)) ([f06dcbd](https://github.com/versini-org/sassysaint-ui/commit/f06dcbdb10a727a9127b55feb7502e6c0734be34))
+
 ## [5.18.0](https://github.com/versini-org/sassysaint-ui/compare/client-v5.17.1...client-v5.18.0) (2025-01-02)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.18.0",
+	"version": "5.18.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -6416,5 +6416,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.18.1": {
+    "Initial CSS": {
+      "fileSize": 71645,
+      "fileSizeGzip": 10191,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 277897,
+      "fileSizeGzip": 85540,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 73421,
+      "fileSizeGzip": 16258,
+      "limit": "17 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 122336,
+      "fileSizeGzip": 38337,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161478,
+      "fileSizeGzip": 45784,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445970,
+      "fileSizeGzip": 128841,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.5.10](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.9...sassysaint-v5.5.10) (2025-01-02)
+
+
+### Bug Fixes
+
+* better variant color for passkey login button ([#749](https://github.com/versini-org/sassysaint-ui/issues/749)) ([9eba73f](https://github.com/versini-org/sassysaint-ui/commit/9eba73f6150a47bdc6f9ee8705ca64741b679ded))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.18.1
+
 ## [5.5.9](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.8...sassysaint-v5.5.9) (2025-01-02)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.5.9",
+	"version": "5.5.10",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.18.1</summary>

## [5.18.1](https://github.com/versini-org/sassysaint-ui/compare/client-v5.18.0...client-v5.18.1) (2025-01-02)


### Bug Fixes

* better variant color for passkey login button ([#749](https://github.com/versini-org/sassysaint-ui/issues/749)) ([9eba73f](https://github.com/versini-org/sassysaint-ui/commit/9eba73f6150a47bdc6f9ee8705ca64741b679ded))
* minor refactor - mostly extracting header toolbar ([#747](https://github.com/versini-org/sassysaint-ui/issues/747)) ([f06dcbd](https://github.com/versini-org/sassysaint-ui/commit/f06dcbdb10a727a9127b55feb7502e6c0734be34))
</details>

<details><summary>sassysaint: 5.5.10</summary>

## [5.5.10](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.9...sassysaint-v5.5.10) (2025-01-02)


### Bug Fixes

* better variant color for passkey login button ([#749](https://github.com/versini-org/sassysaint-ui/issues/749)) ([9eba73f](https://github.com/versini-org/sassysaint-ui/commit/9eba73f6150a47bdc6f9ee8705ca64741b679ded))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.18.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).