### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"packages/client": "5.18.2",
-	"packages/component": "5.5.11"
+	"packages/client": "5.18.3",
+	"packages/component": "5.5.12"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.18.3](https://github.com/versini-org/sassysaint-ui/compare/client-v5.18.2...client-v5.18.3) (2025-01-03)
+
+
+### Bug Fixes
+
+* better dark vs light "scroll to bottom" button color ([#754](https://github.com/versini-org/sassysaint-ui/issues/754)) ([01c68ea](https://github.com/versini-org/sassysaint-ui/commit/01c68eaaf11e1116aba588f171708cf3f83702b6))
+* removing current chat stats from profile due to invalid data ([#752](https://github.com/versini-org/sassysaint-ui/issues/752)) ([85e8014](https://github.com/versini-org/sassysaint-ui/commit/85e8014905e664ef342f795b3509154799157d9f))
+
 ## [5.18.2](https://github.com/versini-org/sassysaint-ui/compare/client-v5.18.1...client-v5.18.2) (2025-01-02)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sassysaint/client",
-	"version": "5.18.2",
+	"version": "5.18.3",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"type": "module",

--- a/packages/client/stats/stats.json
+++ b/packages/client/stats/stats.json
@@ -6504,5 +6504,49 @@
       "limit": "126 kb",
       "passed": true
     }
+  },
+  "5.18.3": {
+    "Initial CSS": {
+      "fileSize": 71871,
+      "fileSizeGzip": 10220,
+      "limit": "11 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant CSS": {
+      "fileSize": 28665,
+      "fileSizeGzip": 7871,
+      "limit": "9 kb",
+      "passed": true
+    },
+    "Initial JS + Vendors (React, auth-provider, etc.)": {
+      "fileSize": 277663,
+      "fileSizeGzip": 85445,
+      "limit": "86 kb",
+      "passed": true
+    },
+    "Lazy App JS": {
+      "fileSize": 73541,
+      "fileSizeGzip": 16285,
+      "limit": "17 kb",
+      "passed": true
+    },
+    "Lazy Header JS": {
+      "fileSize": 121528,
+      "fileSizeGzip": 38112,
+      "limit": "47 kb",
+      "passed": true
+    },
+    "Lazy Message Assistant JS": {
+      "fileSize": 161478,
+      "fileSizeGzip": 45784,
+      "limit": "46 kb",
+      "passed": true
+    },
+    "Lazy Markdown With Extra JS": {
+      "fileSize": 445970,
+      "fileSizeGzip": 128841,
+      "limit": "126 kb",
+      "passed": true
+    }
   }
 }

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.5.12](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.11...sassysaint-v5.5.12) (2025-01-03)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @sassysaint/client bumped to 5.18.3
+
 ## [5.5.11](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.10...sassysaint-v5.5.11) (2025-01-02)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/sassysaint",
-	"version": "5.5.11",
+	"version": "5.5.12",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>client: 5.18.3</summary>

## [5.18.3](https://github.com/versini-org/sassysaint-ui/compare/client-v5.18.2...client-v5.18.3) (2025-01-03)


### Bug Fixes

* better dark vs light "scroll to bottom" button color ([#754](https://github.com/versini-org/sassysaint-ui/issues/754)) ([01c68ea](https://github.com/versini-org/sassysaint-ui/commit/01c68eaaf11e1116aba588f171708cf3f83702b6))
* removing current chat stats from profile due to invalid data ([#752](https://github.com/versini-org/sassysaint-ui/issues/752)) ([85e8014](https://github.com/versini-org/sassysaint-ui/commit/85e8014905e664ef342f795b3509154799157d9f))
</details>

<details><summary>sassysaint: 5.5.12</summary>

## [5.5.12](https://github.com/versini-org/sassysaint-ui/compare/sassysaint-v5.5.11...sassysaint-v5.5.12) (2025-01-03)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @sassysaint/client bumped to 5.18.3
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).