### PR TITLE
feat: adding infinite scrolling to history table

### DIFF
--- a/packages/client/src/common/constants.ts
+++ b/packages/client/src/common/constants.ts
@@ -45,3 +45,6 @@ export const LOCAL_STORAGE_ENGINE_TOGGLE = "engine-toggle";
 export const STATS_SEPARATOR = "==stats==";
 
 export const CLIENT_ID = "b44c68f0-e5b3-4a1d-a3e3-df8632b0223b";
+
+export const INFINITE_SCROLL_THRESHOLD = 10;
+export const INFINITE_SCROLL_LIMIT = 30;

--- a/packages/client/src/modules/History/HistoryTable.tsx
+++ b/packages/client/src/modules/History/HistoryTable.tsx
@@ -13,12 +13,22 @@ import {
 	TableHead,
 	TableRow,
 } from "@versini/ui-table";
-import { useContext, useRef, useState } from "react";
+import {
+	Fragment,
+	useCallback,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 
 import {
 	ACTION_RESET,
 	ACTION_RESTORE,
 	ACTION_SORT,
+	INFINITE_SCROLL_LIMIT,
+	INFINITE_SCROLL_THRESHOLD,
 	LOCAL_STORAGE_PREFIX,
 	LOCAL_STORAGE_SORT,
 } from "../../common/constants";
@@ -90,12 +100,16 @@ export const HistoryTable = ({
 	setFilteredHistory: any;
 }) => {
 	const { user, getAccessToken } = useAuth();
+	const infinityScrollMarkerRef = useRef<HTMLTableRowElement>(null);
 	const chatToDeleteRef = useRef({
 		id: 0,
 		timestamp: "",
 		message: "",
 	});
 	const [showConfirmation, setShowConfirmation] = useState(false);
+	const [lastEntryToLoad, setLastEntryToLoad] = useState(
+		INFINITE_SCROLL_LIMIT + INFINITE_SCROLL_THRESHOLD,
+	);
 	const { state: historyState, dispatch: historyDispatch } =
 		useContext(HistoryContext);
 	const [, setCachedSortDirection] = useLocalStorage({
@@ -152,6 +166,24 @@ export const HistoryTable = ({
 		}
 	};
 
+	const handleObserver = useCallback((entries: IntersectionObserverEntry[]) => {
+		const target = entries[0];
+		if (target.isIntersecting) {
+			setLastEntryToLoad((prev) => prev + INFINITE_SCROLL_LIMIT);
+		}
+	}, []);
+
+	useEffect(() => {
+		const option: IntersectionObserverInit = {
+			// root: null,
+			rootMargin: "20px",
+		};
+		const observer = new IntersectionObserver(handleObserver, option);
+		if (infinityScrollMarkerRef.current) {
+			observer.observe(infinityScrollMarkerRef.current);
+		}
+	});
+
 	return (
 		<>
 			<ConfirmationPanel
@@ -188,6 +220,7 @@ export const HistoryTable = ({
 			>
 				<TableHead>
 					<TableRow>
+						<TableCell className="sr-only">Row</TableCell>
 						<TableCellSort
 							buttonClassName="text-xs sm:text-sm"
 							cellId="timestamp"
@@ -208,80 +241,95 @@ export const HistoryTable = ({
 					</TableRow>
 				</TableHead>
 				<TableBody>
-					{filteredHistory.data.map((item: HistoryItemProps, idx: any) => {
-						return item?.messages?.length > 0 ? (
-							<TableRow key={`${CARDS.HISTORY.TITLE}-${item.id}-${idx}`}>
-								<TableCell
-									component="th"
-									scope="row"
-									className="text-gray-400 sm:whitespace-nowrap text-xs sm:text-sm max-w-20 sm:max-w-none"
-								>
-									{item.timestamp}
-								</TableCell>
-								<TableCell
-									className="max-w-[100px] text-white sm:max-w-full text-xs sm:text-sm"
-									style={{
-										wordBreak: "break-word",
-									}}
-								>
-									{item.messages.length > 0 ? item.messages[0]?.content : ""}
-								</TableCell>
-
-								<TableCell
-									component="th"
-									scope="row"
-									className="text-gray-400"
-									align="center"
-								>
-									{item.model && item.model.startsWith("claude") && (
-										<IconAnthropic size="size-4 sm:size-5" />
+					{filteredHistory.data
+						.slice(0, lastEntryToLoad)
+						.map((item: HistoryItemProps, idx: any) => {
+							return item?.messages?.length > 0 ? (
+								<Fragment key={`${CARDS.HISTORY.TITLE}-${item.id}-${idx}`}>
+									{idx === lastEntryToLoad - INFINITE_SCROLL_THRESHOLD && (
+										<tr ref={infinityScrollMarkerRef} />
 									)}
-									{item.model && item.model.startsWith("gpt") && (
-										<IconOpenAI size="size-4 sm:size-5" />
-									)}
-								</TableCell>
+									<TableRow>
+										<TableCell>{idx + 1}</TableCell>
+										<TableCell
+											component="th"
+											scope="row"
+											className="text-gray-400 sm:whitespace-nowrap text-xs sm:text-sm max-w-20 sm:max-w-none"
+										>
+											{item.timestamp}
+										</TableCell>
+										<TableCell
+											className="max-w-[100px] text-white sm:max-w-full text-xs sm:text-sm"
+											style={{
+												wordBreak: "break-word",
+											}}
+										>
+											{item.messages.length > 0
+												? item.messages[0]?.content
+												: ""}
+										</TableCell>
 
-								<TableCell align="right">
-									<ButtonIcon
-										className="mr-2"
-										focusMode="alt-system"
-										noBorder
-										label="Restore chat"
-										onClick={async () => {
-											const accessToken = await getAccessToken();
-											onClickRestore(item, dispatch, onOpenChange, accessToken);
-										}}
-									>
-										<IconRestore size="size-3" monotone />
-									</ButtonIcon>
-									<ButtonIcon
-										focusMode="alt-system"
-										noBorder
-										label="Delete chat"
-										onClick={() => {
-											chatToDeleteRef.current = {
-												id: item.id,
-												timestamp: item.timestamp,
-												message:
-													item.messages.length > 0
-														? item.messages[0]?.content
-														: "",
-											};
-											setShowConfirmation(!showConfirmation);
-										}}
-									>
-										<div className="text-red-400">
-											<IconDelete size="size-3" monotone />
-										</div>
-									</ButtonIcon>
-								</TableCell>
-							</TableRow>
-						) : null;
-					})}
+										<TableCell
+											component="th"
+											scope="row"
+											className="text-gray-400"
+											align="center"
+										>
+											{item.model && item.model.startsWith("claude") && (
+												<IconAnthropic size="size-4 sm:size-5" />
+											)}
+											{item.model && item.model.startsWith("gpt") && (
+												<IconOpenAI size="size-4 sm:size-5" />
+											)}
+										</TableCell>
+
+										<TableCell align="right">
+											<ButtonIcon
+												className="mr-2"
+												focusMode="alt-system"
+												noBorder
+												label="Restore chat"
+												onClick={async () => {
+													const accessToken = await getAccessToken();
+													onClickRestore(
+														item,
+														dispatch,
+														onOpenChange,
+														accessToken,
+													);
+												}}
+											>
+												<IconRestore size="size-3" monotone />
+											</ButtonIcon>
+											<ButtonIcon
+												focusMode="alt-system"
+												noBorder
+												label="Delete chat"
+												onClick={() => {
+													chatToDeleteRef.current = {
+														id: item.id,
+														timestamp: item.timestamp,
+														message:
+															item.messages.length > 0
+																? item.messages[0]?.content
+																: "",
+													};
+													setShowConfirmation(!showConfirmation);
+												}}
+											>
+												<div className="text-red-400">
+													<IconDelete size="size-3" monotone />
+												</div>
+											</ButtonIcon>
+										</TableCell>
+									</TableRow>
+								</Fragment>
+							) : null;
+						})}
 				</TableBody>
 				<TableFooter>
 					<TableRow>
-						<TableCell colSpan={4}>
+						<TableCell colSpan={1000}>
 							<div>
 								{pluralize(
 									`${filteredHistory.data.length} chat`,

--- a/packages/client/src/modules/History/HistoryTable.tsx
+++ b/packages/client/src/modules/History/HistoryTable.tsx
@@ -18,7 +18,6 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
-	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";


### PR DESCRIPTION
This pull request introduces infinite scroll functionality to the `HistoryTable` component in the `packages/client` module. The most important changes include adding new constants, updating imports, and implementing the infinite scroll logic using an intersection observer.

### Infinite Scroll Implementation:

* [`packages/client/src/common/constants.ts`](diffhunk://#diff-0d96128258a4c9f3ad9a4d272e155fb8257e0ab746a940258d6cc69d7737a150R48-R50): Added `INFINITE_SCROLL_THRESHOLD` and `INFINITE_SCROLL_LIMIT` constants to manage the infinite scroll behavior.

* [`packages/client/src/modules/History/HistoryTable.tsx`](diffhunk://#diff-a885c50f1faf1c52f3bd23c9e14f8f753aacd61bb8062f5bf2acb3ac7987ad5dL16-R31): Updated imports to include necessary hooks and constants for infinite scroll.

* [`packages/client/src/modules/History/HistoryTable.tsx`](diffhunk://#diff-a885c50f1faf1c52f3bd23c9e14f8f753aacd61bb8062f5bf2acb3ac7987ad5dR103-R112): Introduced a new state variable `lastEntryToLoad` and a ref `infinityScrollMarkerRef` to manage the infinite scroll state.

* [`packages/client/src/modules/History/HistoryTable.tsx`](diffhunk://#diff-a885c50f1faf1c52f3bd23c9e14f8f753aacd61bb8062f5bf2acb3ac7987ad5dR169-R186): Implemented the `handleObserver` function using `useCallback` to update `lastEntryToLoad` when the intersection observer detects the marker. Added `useEffect` to set up the intersection observer.

* [`packages/client/src/modules/History/HistoryTable.tsx`](diffhunk://#diff-a885c50f1faf1c52f3bd23c9e14f8f753aacd61bb8062f5bf2acb3ac7987ad5dL211-R253): Modified the rendering logic to slice the `filteredHistory` data based on `lastEntryToLoad` and added a marker row for the intersection observer.