### PR TITLE
fix(history): delay rendering with useLayoutEffect to reduce flashing

### DIFF
--- a/packages/client/src/modules/History/HistoryContent.tsx
+++ b/packages/client/src/modules/History/HistoryContent.tsx
@@ -3,7 +3,7 @@ import { Button } from "@versini/ui-button";
 import { useLocalStorage } from "@versini/ui-hooks";
 import { TableCellSortDirections } from "@versini/ui-table";
 import { TextInput } from "@versini/ui-textinput";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useLayoutEffect, useRef, useState } from "react";
 
 import {
 	ACTION_SEARCH,
@@ -110,7 +110,7 @@ export const HistoryContent = ({ onOpenChange }: HistoryContentProps) => {
 		e.preventDefault();
 	};
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (loadingInitialDataRef.current) {
 			return;
 		}
@@ -131,7 +131,7 @@ export const HistoryContent = ({ onOpenChange }: HistoryContentProps) => {
 		})();
 	});
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (historyState.sortDirection !== filteredHistory.sortedDirection) {
 			const sortedData = [...filteredHistory.data].sort((a, b) => {
 				if (historyState.sortedCell === "timestamp") {


### PR DESCRIPTION
This pull request includes changes to the `HistoryContent` component in `packages/client/src/modules/History/HistoryContent.tsx` to improve the handling of layout effects.

Changes to effect hooks:

* [`packages/client/src/modules/History/HistoryContent.tsx`](diffhunk://#diff-1e332737525e48a576e60868e907180090ef00dede671deafc81fc477449801fL113-R113): Replaced `useEffect` with `useLayoutEffect` in two instances to handle layout updates more efficiently. [[1]](diffhunk://#diff-1e332737525e48a576e60868e907180090ef00dede671deafc81fc477449801fL113-R113) [[2]](diffhunk://#diff-1e332737525e48a576e60868e907180090ef00dede671deafc81fc477449801fL134-R134)

Import updates:

* [`packages/client/src/modules/History/HistoryContent.tsx`](diffhunk://#diff-1e332737525e48a576e60868e907180090ef00dede671deafc81fc477449801fL6-R6): Updated the import statement to include `useLayoutEffect` instead of `useEffect`.